### PR TITLE
Fixing two template issues

### DIFF
--- a/json_schema_for_humans/templates/schema_doc.template.html
+++ b/json_schema_for_humans/templates/schema_doc.template.html
@@ -65,8 +65,8 @@
         {%- endif -%}
         {%- if "properties" in property -%}
             {%- set required_properties = property.get("required") or [] -%}
-            {%- for property_name, property in property["properties"].items() -%}
-                {{ subsection(False, index ~ "_" ~ loop.index, property_name, property) }}
+            {%- for sub_property_name, sub_property in property["properties"].items() -%}
+                {{ subsection(False, index ~ "_" ~ loop.index, sub_property_name, sub_property, required_properties) }}
             {%- endfor -%}
         {%- endif -%}
 
@@ -151,7 +151,7 @@
     {%- endif -%}
 {%- endmacro -%}
 
-{%- macro subsection(expanded, index, property_name, property) -%}
+{%- macro subsection(expanded, index, property_name, property, required_properties) -%}
     {# Resolve reference #}
     {%- set property = (property | resolve_ref(schema)) -%}
 
@@ -206,7 +206,7 @@
     {%- if properties -%}
         {%- set required_properties = schema.get("required") or [] -%}
         {%- for property_name, property in properties.items() -%}
-            {{ subsection(False, loop.index, property_name, property) }}
+            {{ subsection(False, loop.index, property_name, property, required_properties) }}
         {%- endfor -%}
     {%- endif -%}
 </body>


### PR DESCRIPTION
Fixing two template issues that I noticed:
1. Missing "Required" tag on nested objects due to scope of `required_properties`.
   The initial `set required_properties = ...` works because the code is in the global scope but the set statement for nested objects is missed because it's limited to that function call's scope.
2. Processing of nested objects corrupts parent object since the same variable name is used.
    This code `for property_name, property in property["properties"].items()` is problematic because at the end of the for loop, `property` will be set to the last sub-property.  This causes problems for the code after that `for` loop that are using `property`, expecting it to be the parent (not the last sub-property)