### PR TITLE
Use description when it is next to a $ref

### DIFF
--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import re
@@ -110,7 +111,15 @@ def resolve_ref(
                 target = property_dict
                 break
 
-    return target, target_path
+    # Apply other attributes (description, title, etc.) from the referencing schema to the referenced schema
+    # The JSON schema specification does not say if we should do that or not, but I think it is useful
+    result_schema = copy.deepcopy(target)
+    for k, v in property_dict.items():
+        if k == REF:
+            continue
+        result_schema[k] = v
+
+    return result_schema, target_path
 
 
 def python_to_json(value: Any) -> Any:

--- a/tests/cases/description_with_ref.json
+++ b/tests/cases/description_with_ref.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "outer": {
+      "$ref": "#/definitions/inner schema",
+      "description": "We should see this"
+    },
+    "outer2": {
+      "$ref": "#/definitions/inner schema",
+      "description": "We should see this too"
+    }
+  },
+  "required": [
+    "outer"
+  ],
+  "additionalProperties": false,
+  "$id": "my-id",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "inner schema": {
+      "type": "object",
+      "properties": {
+        "inner": {
+          "description": "inner description",
+          "type": "string"
+        }
+      },
+      "required": [
+        "inner"
+      ],
+      "additionalProperties": false,
+      "description": "We should not see this"
+    }
+  }
+}

--- a/tests/generate_test.py
+++ b/tests/generate_test.py
@@ -293,3 +293,14 @@ def test_with_special_chars() -> None:
     expected_targets = ["#pr_nom", "#nomDeFamille", "#a_ge", "#a0_de_quoi_d_autre"]
     for i, expected_target in enumerate(expected_targets):
         assert buttons[i].attrs["data-target"] == expected_target
+
+
+def test_description_with_ref() -> None:
+    """Test that having a description next to a $ref in an object uses that description and not the one from the
+    referenced object
+    """
+    soup = _generate_case("description_with_ref")
+
+    _assert_descriptions(
+        soup, ["We should see this", "inner description", "We should see this too", "inner description"]
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ deps =
     black
     pytest
 commands =
-    black --line-length 120 --check
+    black . --line-length 120 --check
     pytest


### PR DESCRIPTION
There is 2 ways we might want to add a description when using a reference.

Let's take this example:
```json
{
  "type": "object",
  "properties": {
    "outer": {
      "$ref": "#/definitions/inner schema"
    }
  },
  "$id": "my-id",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "inner schema": {
      "type": "object",
      "properties": {
        "inner": {
          "type": "string"
        }
      }
    }
  }
}
```

If we want to see a description under `outer`, we could do:
```json
{
  "type": "object",
  "properties": {
    "outer": {
      "$ref": "#/definitions/inner schema",
      "description": "A description"
    }
  },
  "$id": "my-id",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "inner schema": {
      "type": "object",
      "properties": {
        "inner": {
          "type": "string"
        }
      }
    }
  }
}
```
(Not a valid JSON schema in older drafts, but valid in draft-07)

Or we could do
```json
{
  "type": "object",
  "properties": {
    "outer": {
      "$ref": "#/definitions/inner schema"
    }
  },
  "$id": "my-id",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "inner schema": {
      "type": "object",
      "properties": {
        "inner": {
          "type": "string",
          "description": "A description"
        }
      }
    }
  }
}
```

I prefer the first approach, because it is the only way to have several properties referencing the same definition with different descriptions.

This change will take the description (and all other attributes) next to a "$ref" and use them as if they were on the referenced schema. The description from the referenced schema is still used if there is no description on the referencing schema.