### PR TITLE
Add support for JSON-Schema "examples"-property, UTF-8 compatibility in generated result

### DIFF
--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -397,8 +397,7 @@ def generate_from_file_object(
 
     copy_css_and_js_to_target(result_file.name, copy_css, copy_js)
 
-    # changed for UTF-8-compatibility
-    result_file.write(result.replace("\\/", "/").encode().decode("unicode_escape"))
+    result_file.write(result)
 
 
 def copy_css_and_js_to_target(result_file_path: str, copy_css: bool, copy_js: bool) -> None:

--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -141,6 +141,17 @@ def python_to_json(value: Any) -> Any:
     return value
 
 
+def to_pretty_json(value: Any) -> str:
+    """Filter. Return a pretty printed JSON representation of an object
+
+    Used instead of the built-in tojson filter to be able to display special characters (ensure_ascii parameter)
+    """
+    try:
+        return json.dumps(value, indent=4, separators=(",", ": "), ensure_ascii=False)
+    except:
+        return str(value)
+
+
 def get_type_name(property_dict: Dict[str, Any]) -> str:
     """Filter. Return the type of a property taking into account the type of items for array and enum"""
 
@@ -326,6 +337,7 @@ def generate_from_schema(
     env.filters["resolve_ref"] = resolve_ref
     env.filters["get_numeric_restrictions_text"] = get_numeric_restrictions_text
     env.filters["escape_property_name_for_id"] = escape_property_name_for_id
+    env.filters["to_pretty_json"] = to_pretty_json
     env.tests["combining"] = is_combining
     env.tests["description_short"] = is_text_short
     env.tests["deprecated"] = is_deprecated_look_in_description if deprecated_from_description else is_deprecated

--- a/json_schema_for_humans/schema_doc.css
+++ b/json_schema_for_humans/schema_doc.css
@@ -13,6 +13,14 @@ body {
     margin: 10px;
 }
 
+.btn.example-show.collapsed:before {
+    content: "show"
+}
+
+.btn.example-show:before {
+    content: "hide"
+}
+
 .description.collapse:not(.show) {
     max-height: 100px !important;
     overflow: hidden;

--- a/json_schema_for_humans/schema_doc.css
+++ b/json_schema_for_humans/schema_doc.css
@@ -36,6 +36,7 @@ body {
 
 .badge {
     font-size: 100%;
+	margin-bottom: 0.5rem;
 }
 
 .badge.value-type {
@@ -62,4 +63,8 @@ body {
 
 .accordion div.card:only-child {
     border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+.examples {
+	padding: 1rem !important;
 }

--- a/json_schema_for_humans/templates/schema_doc.template.html
+++ b/json_schema_for_humans/templates/schema_doc.template.html
@@ -32,9 +32,7 @@
     </div>
 {%- endmacro -%}
 
-{%- macro content(index, property_name, property, property_path) -%}
-    {%- set property, property_path = (property | resolve_ref(schema, property_path)) -%}
-
+{%- macro add_description(property) -%}
     {%- set description = property.get("description") | get_description -%}
     {# Display description #}
     {%- if description -%}
@@ -47,11 +45,17 @@
             <a class="collapse-description-link collapsed" data-toggle="collapse" href="#collapseDescription{{ index }}" aria-expanded="false" aria-controls="collapseDescription{{ index }}"></a>
         {%- endif -%}
     {%- endif -%}
+{%- endmacro -%}
+
+{%- macro content(index, property_name, property, property_path) -%}
+    {%- set property, property_path = (property | resolve_ref(schema, property_path)) -%}
 
     {# Handle having oneOf or allOf with only one condition #}
     {%- if "allOf" in property and (property["allOf"] | length) == 1 -%}
+        {{ add_description(property) }}
         {{ content(index, property_name, property["allOf"][0], property_path) }}
     {%- elif "anyOf" in property and (property["anyOf"] | length) == 1 -%}
+        {{ add_description(property) }}
         {{ content(index, property_name, property["anyOf"][0], property_path) }}
     {%- else -%}
         {# Resolve type #}
@@ -65,26 +69,8 @@
         {%- if has_default -%}
             {{ " " }}<span class="badge badge-success default-value">Default: {{ default | python_to_json }}</span>
         {%- endif -%}
-		
-		{%- set examples = property.get("examples") | get_examples -%}
-		{# Display examples #}
-		{%- if examples -%}
-			<br>
-			<div class="badge badge-secondary">Example(s):</div>
-			<a onclick="if(this.getAttribute('aria-expanded') == 'true') { this.innerHTML = 'show' } else { this.innerHTML = 'hide' };" class="badge badge-light" data-toggle="collapse" href="#examples{{ index }}" role="button" aria-expanded="false" aria-controls="examples{{ index }}">
-				show
-			</a>
-			<div id="examples{{ index }}" class="collapse jumbotron examples">
-				<pre>{{ examples | tojson }}</pre>
-			</div>
-		{%- endif -%}
 
-		{%- if "properties" in property -%}
-            {%- set required_properties = property.get("required") or [] -%}
-            {%- for sub_property_name, sub_property in property["properties"].items() -%}
-                {{ subsection(False, loop.index, index, sub_property_name, sub_property, required_properties, property_path) }}
-            {%- endfor -%}
-        {%- endif -%}
+        {{ add_description(property) }}
     
         {# Handle actual requirement #}
         {%- if "allOf" in property -%}
@@ -164,6 +150,31 @@
                 </div>
             {%- endif -%}
         {%- endif -%}
+
+        {%- set examples = (property.get("examples") or []) -%}
+		{# Display examples #}
+		{%- if examples -%}
+            <br/>
+            <div class="badge badge-secondary">Example{% if examples|length > 1 %}s{% endif %}:</div>
+            <br/>
+
+            {%- for example in examples -%}
+                {%- set example_is_long = example is not description_short -%}
+                {%- if example_is_long -%}
+                    <button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#{{ index }}_ex{{ loop.index }}" aria-controls="{{ index }}_ex{{ loop.index }}"></button>
+                {%- endif -%}
+                <div id="{{ index }}_ex{{ loop.index }}" class="{% if example_is_long %}collapse {% endif %}jumbotron examples">
+                    <pre>{{ example | tojson(4) }}</pre>
+                </div>
+            {%- endfor -%}
+		{%- endif -%}
+
+        {%- if "properties" in property -%}
+            {%- set required_properties = property.get("required") or [] -%}
+            {%- for sub_property_name, sub_property in property["properties"].items() -%}
+                {{ subsection(False, loop.index, index, sub_property_name, sub_property, required_properties, property_path) }}
+            {%- endfor -%}
+        {%- endif -%}
     {%- endif -%}
 {%- endmacro -%}
 
@@ -213,28 +224,13 @@
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-	<link href="jsonTree.css" rel="stylesheet">
-	<script src="jsonTree.js"></script>
 	<link rel="stylesheet" type="text/css" href="schema_doc.css">
     <script src="https://use.fontawesome.com/facf9fa52c.js"></script>
     <script src="schema_doc.min.js"></script>
-	<script>
-	// pretty-print all Examples
-		function prettifyJSONexamples(){
-			examples = document.getElementsByClassName("examples");
-			for (var i = 0; i < examples.length; i++) {
-				raw_json_str =  examples.item(i).textContent;
-				parsed_json = JSON.parse(raw_json_str);
-				for (e = 0; e < parsed_json.length; e++) {
-					examples.item(i).innerHTML = ('<pre>').concat(JSON.stringify(parsed_json[e], undefined, 4)).concat('</pre>');
-				}
-			};
-		}	
-	</script>
     {%- set title = schema.get("title") -%}
     <title>{%- if title -%}{{ title }}{%- else -%}Schema Docs{%- endif -%}</title>
 </head>
-<body onload="anchorOnLoad(); prettifyJSONexamples();">
+<body onload="anchorOnLoad();">
     {%- if title -%}
         <h1>{{ title }}</h1>
     {%- endif -%}

--- a/json_schema_for_humans/templates/schema_doc.template.html
+++ b/json_schema_for_humans/templates/schema_doc.template.html
@@ -227,6 +227,7 @@
 	<link rel="stylesheet" type="text/css" href="schema_doc.css">
     <script src="https://use.fontawesome.com/facf9fa52c.js"></script>
     <script src="schema_doc.min.js"></script>
+    <meta charset="utf-8"/>
     {%- set title = schema.get("title") -%}
     <title>{%- if title -%}{{ title }}{%- else -%}Schema Docs{%- endif -%}</title>
 </head>

--- a/json_schema_for_humans/templates/schema_doc.template.html
+++ b/json_schema_for_humans/templates/schema_doc.template.html
@@ -65,13 +65,27 @@
         {%- if has_default -%}
             {{ " " }}<span class="badge badge-success default-value">Default: {{ default | python_to_json }}</span>
         {%- endif -%}
-        {%- if "properties" in property -%}
+		
+		{%- set examples = property.get("examples") | get_examples -%}
+		{# Display examples #}
+		{%- if examples -%}
+			<br>
+			<div class="badge badge-secondary">Example(s):</div>
+			<a onclick="if(this.getAttribute('aria-expanded') == 'true') { this.innerHTML = 'show' } else { this.innerHTML = 'hide' };" class="badge badge-light" data-toggle="collapse" href="#examples{{ index }}" role="button" aria-expanded="false" aria-controls="examples{{ index }}">
+				show
+			</a>
+			<div id="examples{{ index }}" class="collapse jumbotron examples">
+				<pre>{{ examples | tojson }}</pre>
+			</div>
+		{%- endif -%}
+
+		{%- if "properties" in property -%}
             {%- set required_properties = property.get("required") or [] -%}
             {%- for sub_property_name, sub_property in property["properties"].items() -%}
                 {{ subsection(False, loop.index, index, sub_property_name, sub_property, required_properties, property_path) }}
             {%- endfor -%}
         {%- endif -%}
-
+    
         {# Handle actual requirement #}
         {%- if "allOf" in property -%}
             <div class="all-of-value">{{ tabbed_section("allOf", property, property_path, index) }}</div>
@@ -199,13 +213,28 @@
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-    <link rel="stylesheet" type="text/css" href="schema_doc.css">
+	<link href="jsonTree.css" rel="stylesheet">
+	<script src="jsonTree.js"></script>
+	<link rel="stylesheet" type="text/css" href="schema_doc.css">
     <script src="https://use.fontawesome.com/facf9fa52c.js"></script>
     <script src="schema_doc.min.js"></script>
+	<script>
+	// pretty-print all Examples
+		function prettifyJSONexamples(){
+			examples = document.getElementsByClassName("examples");
+			for (var i = 0; i < examples.length; i++) {
+				raw_json_str =  examples.item(i).textContent;
+				parsed_json = JSON.parse(raw_json_str);
+				for (e = 0; e < parsed_json.length; e++) {
+					examples.item(i).innerHTML = ('<pre>').concat(JSON.stringify(parsed_json[e], undefined, 4)).concat('</pre>');
+				}
+			};
+		}	
+	</script>
     {%- set title = schema.get("title") -%}
     <title>{%- if title -%}{{ title }}{%- else -%}Schema Docs{%- endif -%}</title>
 </head>
-<body onload="anchorOnLoad()">
+<body onload="anchorOnLoad(); prettifyJSONexamples();">
     {%- if title -%}
         <h1>{{ title }}</h1>
     {%- endif -%}
@@ -228,6 +257,5 @@
     {% else %}
         {{ content(0, schema.get("title", "Main schema"), schema, schema_path) }}
     {%- endif -%}
-
 </body>
 </html>

--- a/json_schema_for_humans/templates/schema_doc.template.html
+++ b/json_schema_for_humans/templates/schema_doc.template.html
@@ -164,7 +164,7 @@
                     <button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#{{ index }}_ex{{ loop.index }}" aria-controls="{{ index }}_ex{{ loop.index }}"></button>
                 {%- endif -%}
                 <div id="{{ index }}_ex{{ loop.index }}" class="{% if example_is_long %}collapse {% endif %}jumbotron examples">
-                    <pre>{{ example | tojson(4) }}</pre>
+                    <pre>{{ example | to_pretty_json }}</pre>
                 </div>
             {%- endfor -%}
 		{%- endif -%}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click
 htmlmin
 jinja2
 markdown2
+Pygments

--- a/tests/cases/with_examples.json
+++ b/tests/cases/with_examples.json
@@ -29,8 +29,7 @@
       "examples": [
         {
           "birthplace": "Haarlem, Netherlands",
-          "gender": "male",
-          "height_cm": 175,
+          "favorite_emoji": "🐍",
           "motto": "Beautiful is better than ugly.\\nExplicit is better than implicit.\\nSimple is better than complex.\\nComplex is better than complicated.\\nFlat is better than nested.\\nSparse is better than dense.\\nReadability counts.\\nSpecial cases aren't special enough to break the rules.\\nAlthough practicality beats purity.\\nErrors should never pass silently.\\nUnless explicitly silenced.\\nIn the face of ambiguity, refuse the temptation to guess.\\nThere should be one-- and preferably only one --obvious way to do it.\\nAlthough that way may not be obvious at first unless you're Dutch.\\nNow is better than never.\\nAlthough never is often better than *right* now.\\nIf the implementation is hard to explain, it's a bad idea.\\nIf the implementation is easy to explain, it may be a good idea.\\nNamespaces are one honking great idea -- let's do more of those!"
         }
       ]

--- a/tests/cases/with_examples.json
+++ b/tests/cases/with_examples.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "the person's first name",
+      "title": "Person",
+      "examples": ["Guido", "BDFL"]
+    },
+    "lastName": {
+      "type": "string",
+      "description": "The person's last name.",
+      "title": "Person",
+      "examples": ["Van Rossum"]
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0,
+      "title": "Person",
+      "examples": [64]
+    },
+    "moreInfo": {
+      "description": "Any more info you want as an object",
+      "type": "object",
+      "examples": [
+        {
+          "birthplace": "Haarlem, Netherlands",
+          "gender": "male",
+          "height_cm": 175,
+          "motto": "Beautiful is better than ugly.\\nExplicit is better than implicit.\\nSimple is better than complex.\\nComplex is better than complicated.\\nFlat is better than nested.\\nSparse is better than dense.\\nReadability counts.\\nSpecial cases aren't special enough to break the rules.\\nAlthough practicality beats purity.\\nErrors should never pass silently.\\nUnless explicitly silenced.\\nIn the face of ambiguity, refuse the temptation to guess.\\nThere should be one-- and preferably only one --obvious way to do it.\\nAlthough that way may not be obvious at first unless you're Dutch.\\nNow is better than never.\\nAlthough never is often better than *right* now.\\nIf the implementation is hard to explain, it's a bad idea.\\nIf the implementation is easy to explain, it may be a good idea.\\nNamespaces are one honking great idea -- let's do more of those!"
+        }
+      ]
+    }
+  }
+}

--- a/tests/generate_test.py
+++ b/tests/generate_test.py
@@ -322,8 +322,7 @@ def test_with_examples() -> None:
         "64",
         """{
     "birthplace": "Haarlem, Netherlands",
-    "gender": "male",
-    "height_cm": 175,
-    "motto": "Beautiful is better than ugly.\\\\nExplicit is better than implicit.\\\\nSimple is better than complex.\\\\nComplex is better than complicated.\\\\nFlat is better than nested.\\\\nSparse is better than dense.\\\\nReadability counts.\\\\nSpecial cases aren\\u0027t special enough to break the rules.\\\\nAlthough practicality beats purity.\\\\nErrors should never pass silently.\\\\nUnless explicitly silenced.\\\\nIn the face of ambiguity, refuse the temptation to guess.\\\\nThere should be one-- and preferably only one --obvious way to do it.\\\\nAlthough that way may not be obvious at first unless you\\u0027re Dutch.\\\\nNow is better than never.\\\\nAlthough never is often better than *right* now.\\\\nIf the implementation is hard to explain, it\\u0027s a bad idea.\\\\nIf the implementation is easy to explain, it may be a good idea.\\\\nNamespaces are one honking great idea -- let\\u0027s do more of those!"
+    "favorite_emoji": "🐍",
+    "motto": "Beautiful is better than ugly.\\\\nExplicit is better than implicit.\\\\nSimple is better than complex.\\\\nComplex is better than complicated.\\\\nFlat is better than nested.\\\\nSparse is better than dense.\\\\nReadability counts.\\\\nSpecial cases aren't special enough to break the rules.\\\\nAlthough practicality beats purity.\\\\nErrors should never pass silently.\\\\nUnless explicitly silenced.\\\\nIn the face of ambiguity, refuse the temptation to guess.\\\\nThere should be one-- and preferably only one --obvious way to do it.\\\\nAlthough that way may not be obvious at first unless you're Dutch.\\\\nNow is better than never.\\\\nAlthough never is often better than *right* now.\\\\nIf the implementation is hard to explain, it's a bad idea.\\\\nIf the implementation is easy to explain, it may be a good idea.\\\\nNamespaces are one honking great idea -- let's do more of those!"
 }""",
     ]

--- a/tests/generate_test.py
+++ b/tests/generate_test.py
@@ -304,3 +304,26 @@ def test_description_with_ref() -> None:
     _assert_descriptions(
         soup, ["We should see this", "inner description", "We should see this too", "inner description"]
     )
+
+
+def test_with_examples() -> None:
+    soup = _generate_case("with_examples")
+
+    examples_label = soup.find_all("div", class_=["badge", "badge-secondary"])
+    examples_label_text = [ex.text for ex in examples_label]
+    assert examples_label_text == ["Examples:", "Example:", "Example:", "Example:"]
+
+    examples_content = soup.find_all("div", class_="examples")
+    examples_content_text = [ex.findChildren()[0].text for ex in examples_content]
+    assert examples_content_text == [
+        '"Guido"',
+        '"BDFL"',
+        '"Van Rossum"',
+        "64",
+        """{
+    "birthplace": "Haarlem, Netherlands",
+    "gender": "male",
+    "height_cm": 175,
+    "motto": "Beautiful is better than ugly.\\\\nExplicit is better than implicit.\\\\nSimple is better than complex.\\\\nComplex is better than complicated.\\\\nFlat is better than nested.\\\\nSparse is better than dense.\\\\nReadability counts.\\\\nSpecial cases aren\\u0027t special enough to break the rules.\\\\nAlthough practicality beats purity.\\\\nErrors should never pass silently.\\\\nUnless explicitly silenced.\\\\nIn the face of ambiguity, refuse the temptation to guess.\\\\nThere should be one-- and preferably only one --obvious way to do it.\\\\nAlthough that way may not be obvious at first unless you\\u0027re Dutch.\\\\nNow is better than never.\\\\nAlthough never is often better than *right* now.\\\\nIf the implementation is hard to explain, it\\u0027s a bad idea.\\\\nIf the implementation is easy to explain, it may be a good idea.\\\\nNamespaces are one honking great idea -- let\\u0027s do more of those!"
+}""",
+    ]


### PR DESCRIPTION
Dear maintainers,

first of all I would like to thank you for this wonderful Python library. For a current research project we need the presentation of JSON-examples in the HTML-documentation of our JSON-schemas. I have made the necessary changes to a local version of this library and would like to share them with you.
The 2 changes made are:
1. representation of the property "examples" (not supported so far):

![image](https://user-images.githubusercontent.com/25271469/80643208-fda5fd80-8a67-11ea-939e-0bf323521be6.png)

2. decoding unicode-escapes in the generated result

I'm looking forward to your review.

Kind regards
