### PR TITLE
pyyaml needed by tox to test correctly?

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     beautifulsoup4
     black
     pytest
+    pyyaml
 commands =
     black . --line-length 120 --check
     pytest


### PR DESCRIPTION
Not sure why but tox doesn't work for me (Powershell, Windows 10) unless I add pyyaml.  Adding as a proposal here, unless it's supposed to be picked up some other way?

Tox fails with this:
```
_____________________________________________________________________________ ERROR collecting tests/generate_test.py _____________________________________________________________________________ 
ImportError while importing test module '...\tests\generate_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests\generate_test.py:8: in <module>
    from json_schema_for_humans.generate import generate_from_file_object, generate_from_schema
json_schema_for_humans\generate.py:17: in <module>
    import yaml
E   ModuleNotFoundError: No module named 'yaml' 
```