### PR TITLE
Use title for definition name where ref file name isn't available

### DIFF
--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -182,6 +182,8 @@ class SchemaNode:
     def definition_name(self) -> str:
         if self.ref_path:
             return self.ref_path.split("/")[-1]
+        if self.title:
+            return self.title
         return ""
 
     @property


### PR DESCRIPTION
Tabs get a default title unless `anyOf`/`oneOf`/`allOf`s reference another schema at the moment. In the case they don't reference another schema, check for a `title` field and use that as the tab title if available.

**Before**
![image](https://user-images.githubusercontent.com/34583553/94547110-bace9880-0246-11eb-9c9c-ef5554ec81ac.png)

**After**
![image](https://user-images.githubusercontent.com/34583553/94547145-c7eb8780-0246-11eb-96f4-a4d040f4e5d7.png)
