### PR TITLE
Increased the left padding of section properties to make the doc more readable

### DIFF
--- a/json_schema_for_humans/templates/js/section_properties.html
+++ b/json_schema_for_humans/templates/js/section_properties.html
@@ -29,7 +29,7 @@
         <div id="{{ html_id }}"
              class="collapse{% if expanded %} show{% endif %} property-definition-div" aria-labelledby="heading{{ html_id }}"
              data-parent="#accordion{{ html_id }}">
-            <div class="card-body">
+            <div class="card-body pl-5">
                 {%- if sub_property.is_pattern_property -%}
                     <h2 class="handle">
                         <label>Pattern Property</label>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/429665/106438006-e6cf8400-649b-11eb-8718-8d530a3768ea.png)


Please refer https://getbootstrap.com/docs/4.4/utilities/spacing/#notation for the change.