### PR TITLE
Fix issue with unescaped commas

### DIFF
--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -1221,7 +1221,7 @@ def get_numeric_restrictions_text(schema_node: SchemaNode, before_value: str = "
 def escape_property_name_for_id(property_name: str) -> str:
     """Filter. Escape unsafe characters in a property name so that it can be used in a HTML id"""
 
-    escaped = re.sub("[^0-9a-zA-Z_,-]", "_", str(property_name))
+    escaped = re.sub("[^0-9a-zA-Z_-]", "_", str(property_name))
     if not escaped[0].isalpha():
         escaped = "a" + escaped
     return escaped


### PR DESCRIPTION
The uncollapsing of properties with a comma (e.g. "0,0") was not working because the comma was not being escaped (same as issue #70 had with points). Escaping them fixes the issue.