### PR TITLE
Allow filepath to templates to be configured

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -12,12 +12,12 @@
     "description_is_markdown": {
       "type": "boolean",
       "default": true,
-      "description": "Whether to consider the description as markdown and render it accordingly"
+      "description": "Whether to consider the description as markdown and render it accordingly."
     },
     "expand_buttons": {
       "type": "boolean",
       "default": false,
-      "description": "Add an `Expand all` and a `Collapse all` button at the top of the generated documentation"
+      "description": "Add an `Expand all` and a `Collapse all` button at the top of the generated documentation."
     },
     "show_breadcrumbs": {
       "type": "boolean",
@@ -42,28 +42,38 @@
     "deprecated_from_description": {
       "type": "boolean",
       "default": false,
-      "description": "Mark a property as deprecated (with a big red badge) if the description contains the string `[Deprecated`"
+      "description": "Mark a property as deprecated (with a big red badge) if the description contains the string `[Deprecated`."
     },
     "default_from_description" : {
       "type": "boolean",
       "default": false,
-      "description": "Extract the default value of a property from the description like this: ``[Default `the_default_value`]``.\n\nThe default value from the \"default\" attribute will be used in priority"
+      "description": "Extract the default value of a property from the description like this: ``[Default `the_default_value`]``.\n\nThe default value from the \"default\" attribute will be used in priority."
     },
     "copy_css": {
       "type": "boolean",
       "default": true,
-      "description": "Copy `schema_doc.css` to the same directory as `RESULT_FILE` after generation"
+      "description": "Copy `schema_doc.css` to the same directory as `RESULT_FILE` after generation."
     },
     "copy_js": {
       "type": "boolean",
       "default": true,
-      "description": "Copy `schema_doc.min.js` to the same directory as `RESULT_FILE` after generation.\n\nThis file contains the logic for the anchor links"
+      "description": "Copy `schema_doc.min.js` to the same directory as `RESULT_FILE` after generation.\n\nThis file contains the logic for the anchor links."
     },
+    "template_base": {
+      "type": "string",
+      "default": "js",
+      "description": "The file system path to where the folder of templates, given using the `template_folder` option, is available."
+    },
+    "template_folder": {
+      "type": "string",
+      "default": "templates",
+      "description": "The name of the folder in which templates are managed, with a default of 'templates'."
+    },    
     "template_name": {
       "type": "string",
       "enum": ["flat", "js"],
       "default": "js",
-      "description": "The HTML templates to use to render the documentation.\n\n`js` is the default one, it uses javascript for anchor links, collapsible sections and tabs. `flat` uses no javascript, but has no interactivity."
+      "description": "The name of the set of HTML templates to use to render the documentation.\n\n`js` is the default and uses javascript for anchor links, collapsible sections and tabs. `flat` uses no javascript, but has no interactivity."
     },
     "markdown_options": {
       "type": "object",

--- a/config_schema.json
+++ b/config_schema.json
@@ -59,15 +59,9 @@
       "default": true,
       "description": "Copy `schema_doc.min.js` to the same directory as `RESULT_FILE` after generation.\n\nThis file contains the logic for the anchor links."
     },
-    "template_base": {
-      "type": "string",
-      "default": "js",
-      "description": "The file system path to where the folder of templates, given using the `template_folder` option, is available."
-    },
     "template_folder": {
       "type": "string",
-      "default": "templates",
-      "description": "The name of the folder in which templates are managed, with a default of 'templates'."
+      "description": "The file system path to the folder of templates, with a default of the `templates` folder within the module."
     },    
     "template_name": {
       "type": "string",

--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -104,8 +104,7 @@ class GenerationConfiguration:
     copy_js: bool = True
     link_to_reused_ref: bool = True
     recursive_detection_depth: int = 25
-    template_base: str = os.path.dirname(__file__)
-    template_folder: str = "templates"
+    template_folder: str = os.path.join(os.path.dirname(__file__), "templates")
     template_name: str = "js"
     # markdown2 extra parameters can be added here: https://github.com/trentm/python-markdown2/wiki/Extras
     markdown_options: Any = field(
@@ -1257,7 +1256,7 @@ def generate_from_schema(
         link_to_reused_ref=link_to_reused_ref,
     )
 
-    template_folder = os.path.join(config.template_base, config.template_folder, config.template_name)
+    template_folder = os.path.join(config.template_folder, config.template_name)
     base_template_path = os.path.join(template_folder, TEMPLATE_FILE_NAME)
 
     md = markdown2.Markdown(extras=config.markdown_options)
@@ -1385,7 +1384,7 @@ def copy_css_and_js_to_target(result_file_path: str, config: GenerationConfigura
         return
 
     target_directory = os.path.dirname(result_file_path)
-    source_directory = os.path.join(config.template_base, config.template_folder, config.template_name)
+    source_directory = os.path.join(config.template_folder, config.template_name)
     if target_directory == source_directory:
         return
 

--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -24,7 +24,6 @@ from pygments.formatters.html import HtmlFormatter
 from pygments.lexers.javascript import JavascriptLexer
 from pytz import reference
 
-TEMPLATE_FOLDER = "templates"
 TEMPLATE_FILE_NAME = "base.html"
 CSS_FILE_NAME = "schema_doc.css"
 JS_FILE_NAME = "schema_doc.min.js"
@@ -105,6 +104,8 @@ class GenerationConfiguration:
     copy_js: bool = True
     link_to_reused_ref: bool = True
     recursive_detection_depth: int = 25
+    template_base: str = os.path.dirname(__file__)
+    template_folder: str = "templates"
     template_name: str = "js"
     # markdown2 extra parameters can be added here: https://github.com/trentm/python-markdown2/wiki/Extras
     markdown_options: Any = field(
@@ -1256,7 +1257,7 @@ def generate_from_schema(
         link_to_reused_ref=link_to_reused_ref,
     )
 
-    template_folder = os.path.join(os.path.dirname(__file__), TEMPLATE_FOLDER, config.template_name)
+    template_folder = os.path.join(config.template_base, config.template_folder, config.template_name)
     base_template_path = os.path.join(template_folder, TEMPLATE_FILE_NAME)
 
     md = markdown2.Markdown(extras=config.markdown_options)
@@ -1384,7 +1385,7 @@ def copy_css_and_js_to_target(result_file_path: str, config: GenerationConfigura
         return
 
     target_directory = os.path.dirname(result_file_path)
-    source_directory = os.path.join(os.path.dirname(__file__), TEMPLATE_FOLDER, config.template_name)
+    source_directory = os.path.join(config.template_base, config.template_folder, config.template_name)
     if target_directory == source_directory:
         return
 


### PR DESCRIPTION

Changes:

* Move global `TEMPLATE_FOLDER` var onto configuration object as `template_folder`, default of `templates`
* Create `template_base` configuration option for the base path name, with default of the module's path
* Update documentation of config options to describe these, and standardize trailing punctuation

Closes #78 