### PR TITLE
Fix invalid HTML as `<footer>` must not be sibling of `<body>`

### DIFF
--- a/json_schema_for_humans/templates/flat/base.html
+++ b/json_schema_for_humans/templates/flat/base.html
@@ -19,8 +19,9 @@
     {%- endif -%}
 
     {{ content(schema) }}
+
+    <footer>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on {{ get_local_time() }}</p>
+    </footer>
 </body>
-<footer>
-    <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on {{ get_local_time() }}</p>
-</footer>
 </html>

--- a/json_schema_for_humans/templates/js/base.html
+++ b/json_schema_for_humans/templates/js/base.html
@@ -29,8 +29,9 @@
     {%- endif -%}
 
     {{ content(schema) }}
+
+    <footer>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on {{ get_local_time() }}</p>
+    </footer>
 </body>
-<footer>
-    <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on {{ get_local_time() }}</p>
-</footer>
 </html>


### PR DESCRIPTION
The `<footer>` element must not be placed outside of `<body>`.

According to the [MDN docs on the `html` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html),

> Permitted content: One <head> element, followed by one <body> element.

I triggered regeneration of the examples (which also contain the wrong HTML) locally, but that resulted in additional unrelated changes, so I didn't commit any changes to the examples.