### PR TITLE
Add examples_as_yaml option

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -62,7 +62,7 @@
     "templates_directory": {
       "type": "string",
       "description": "The file system path to the directory containing templates, with a default of the `templates` directory within the library source code."
-    },    
+    },
     "template_name": {
       "type": "string",
       "enum": ["flat", "js", "md"],
@@ -73,6 +73,11 @@
       "type": "boolean",
       "default": true,
       "description": "Whether to render table of contents."
+    },
+    "examples_as_yaml": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to display examples as YAML instead of JSON"
     },
     "markdown_options": {
       "type": "object",
@@ -87,7 +92,7 @@
           "tables": null,
           "break-on-newline": true,
           "cuddled-lists": true
-        } 
+        }
       ]
     },
     "template_md_options": {

--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -70,11 +70,13 @@ def generate_from_schema(
     env.filters["get_first_property"] = jinja_filters.get_first_property
     env.filters["get_undocumented_required_properties"] = jinja_filters.get_undocumented_required_properties
     env.filters["highlight_json_example"] = jinja_filters.highlight_json_example
+    env.filters["highlight_yaml_example"] = jinja_filters.highlight_yaml_example
     env.filters["first_line"] = jinja_filters.first_line
 
     env.tests["combining"] = jinja_filters.is_combining
     env.tests["description_short"] = jinja_filters.is_text_short
     env.tests["deprecated"] = lambda schema: jinja_filters.deprecated(config, schema)
+    env.globals["examples_as_yaml"] = config.examples_as_yaml
     env.globals["get_local_time"] = jinja_filters.get_local_time
 
     with open(base_template_path, "r") as template_fp:

--- a/json_schema_for_humans/generation_configuration.py
+++ b/json_schema_for_humans/generation_configuration.py
@@ -29,6 +29,7 @@ class GenerationConfiguration:
     templates_directory: str = os.path.join(os.path.dirname(__file__), "templates")
     template_name: str = "js"
     show_toc: bool = True
+    examples_as_yaml: bool = False
     # markdown2 extra parameters can be added here: https://github.com/trentm/python-markdown2/wiki/Extras
     markdown_options: Dict[str, Any] = None
     template_md_options: Dict[str, Any] = None

--- a/json_schema_for_humans/jinja_filters.py
+++ b/json_schema_for_humans/jinja_filters.py
@@ -1,4 +1,6 @@
 import re
+import json
+import yaml
 from datetime import datetime
 from typing import List, Any
 
@@ -8,6 +10,7 @@ from markupsafe import Markup
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers.javascript import JavascriptLexer
+from pygments.lexers.data import YamlLexer
 from pytz import reference
 
 from json_schema_for_humans import const
@@ -222,3 +225,9 @@ def get_local_time() -> str:
 def highlight_json_example(example_text: str) -> str:
     """Filter. Return an highlighted version of the provided JSON text"""
     return highlight(example_text, JavascriptLexer(), HtmlFormatter())
+
+
+def highlight_yaml_example(example_text: str) -> str:
+    """Filter. Return a YAML version of the provided JSON text"""
+    yaml_text = yaml.dump(json.loads(example_text), allow_unicode=True)
+    return highlight(yaml_text, YamlLexer(), HtmlFormatter())

--- a/json_schema_for_humans/templates/flat/section_examples.html
+++ b/json_schema_for_humans/templates/flat/section_examples.html
@@ -5,10 +5,17 @@
 {%- for example in examples -%}
     {%- set example_id = schema.html_id ~ "_ex" ~ loop.index -%}
     {%- set example_is_long = example is not description_short -%}
+    {%- set example_is_json = not examples_as_yaml -%}
+    {%- set example_is_yaml = examples_as_yaml -%}
     {%- if example_is_long -%}
         <button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#{{ example_id }}" aria-controls="{{ example_id }}"></button>
     {%- endif -%}
     <div id="{{ example_id }}" class="{% if example_is_long %}collapse {% endif %}jumbotron examples">
-        {{ example | highlight_json_example }}
+        {%- if example_is_json -%}
+            {{ example | highlight_json_example }}
+        {%- endif -%}
+        {%- if example_is_yaml -%}
+            {{ example | highlight_yaml_example }}
+        {%- endif -%}
     </div>
 {%- endfor -%}

--- a/json_schema_for_humans/templates/js/section_examples.html
+++ b/json_schema_for_humans/templates/js/section_examples.html
@@ -5,10 +5,17 @@
 {%- for example in examples -%}
     {%- set example_id = schema.html_id ~ "_ex" ~ loop.index -%}
     {%- set example_is_long = example is not description_short -%}
+    {%- set example_is_json = not examples_as_yaml -%}
+    {%- set example_is_yaml = examples_as_yaml -%}
     {%- if example_is_long -%}
         <button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#{{ example_id }}" aria-controls="{{ example_id }}"></button>
     {%- endif -%}
     <div id="{{ example_id }}" class="{% if example_is_long %}collapse {% endif %}jumbotron examples">
-        {{ example | highlight_json_example }}
+        {%- if example_is_json -%}
+            {{ example | highlight_json_example }}
+        {%- endif -%}
+        {%- if example_is_yaml -%}
+            {{ example | highlight_yaml_example }}
+        {%- endif -%}
     </div>
 {%- endfor -%}

--- a/json_schema_for_humans/templates/md/section_examples.html
+++ b/json_schema_for_humans/templates/md/section_examples.html
@@ -2,7 +2,16 @@
 
 {% for example in examples %}
 {% set example_id = schema.html_id ~ "_ex" ~ loop.index %}
+{%- set example_is_json = not examples_as_yaml -%}
+{%- set example_is_yaml = examples_as_yaml -%}
+{%- if example_is_json -%}
 ```json
 {{ example }}
 ```
+{%- endif -%}
+{%- if example_is_yaml -%}
+```yaml
+{{ example | highlight_yaml_example }}
+```
+{%- endif -%}
 {% endfor %}

--- a/tests/generate_test.py
+++ b/tests/generate_test.py
@@ -387,6 +387,38 @@ def test_with_examples() -> None:
 }\n""",
     ]
 
+def test_with_yaml_examples() -> None:
+    soup = generate_case("with_examples", GenerationConfiguration(examples_as_yaml=True))
+
+    examples_label = soup.find_all("div", class_=["badge", "badge-secondary"])
+    examples_label_text = [ex.text for ex in examples_label]
+    assert examples_label_text == ["Examples:", "Example:", "Example:", "Example:"]
+
+    examples_content = soup.find_all("div", class_="examples")
+    examples_content_text = [ex.findChildren()[0].text for ex in examples_content]
+    assert examples_content_text == [
+        "Guido\n",
+        "...\n",
+        "BDFL\n",
+        "...\n",
+        "Van Rossum\n",
+        "...\n",
+        "64\n",
+        "...\n",
+        "birthplace: Haarlem, Netherlands\n",
+        "favorite_emoji: 🐍\n",
+        "motto: Beautiful is better than ugly.\\nExplicit is better than implicit.\\nSimple is\n",
+        "  better than complex.\\nComplex is better than complicated.\\nFlat is better than nested.\\nSparse\n",
+        "  is better than dense.\\nReadability counts.\\nSpecial cases aren't special enough\n",
+        "  to break the rules.\\nAlthough practicality beats purity.\\nErrors should never pass\n",
+        "  silently.\\nUnless explicitly silenced.\\nIn the face of ambiguity, refuse the temptation\n",
+        "  to guess.\\nThere should be one-- and preferably only one --obvious way to do it.\\nAlthough\n",
+        "  that way may not be obvious at first unless you're Dutch.\\nNow is better than never.\\nAlthough\n",
+        "  never is often better than *right* now.\\nIf the implementation is hard to explain,\n",
+        "  it's a bad idea.\\nIf the implementation is easy to explain, it may be a good idea.\\nNamespaces\n",
+        "  are one honking great idea -- let's do more of those!\n",
+    ]
+
 
 def test_pattern_properties() -> None:
     soup = generate_case("pattern_properties")


### PR DESCRIPTION
Adds an option to display examples as YAML instead of JSON.
I'm not too familiar with Python, let me know if I've missed anything.