### PR TITLE
Throw appropriate and informative error if the output dir is missing

### DIFF
--- a/json_schema_for_humans/generate.py
+++ b/json_schema_for_humans/generate.py
@@ -128,6 +128,11 @@ def generate_from_filename(
     elif isinstance(schema_file_name, Path):
         schema_file_name = str(schema_file_name.resolve())
 
+    if not os.path.exists(os.path.dirname(os.path.realpath(result_file_name))):
+        raise FileNotFoundError(
+            f"Output directory {os.path.dirname(os.path.realpath(result_file_name))} does not exist"
+        )
+
     rendered_schema_doc = generate_from_schema(
         schema_file_name,
         minify=minify,
@@ -168,6 +173,11 @@ def generate_from_file_object(
         copy_js=copy_js,
         link_to_reused_ref=link_to_reused_ref,
     )
+
+    if not os.path.exists(os.path.dirname(os.path.realpath(result_file.name))):
+        raise FileNotFoundError(
+            f"Output directory {os.path.dirname(os.path.realpath(result_file.name))} does not exist"
+        )
 
     result = generate_from_schema(schema_file, config=config)
 
@@ -255,7 +265,10 @@ def main(
         config_parameters=config,
     )
 
-    generate_from_file_object(schema_file, result_file, config=config)
+    try:
+        generate_from_file_object(schema_file, result_file, config=config)
+    except FileNotFoundError as e:
+        raise click.ClickException(str(e)) from e
     duration = datetime.now() - start
     print(f"Generated {result_file.name} in {duration}")
 

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -117,6 +117,26 @@ def test_generate_from_file_name(tmp_path: Path) -> None:
     assert (tmp_path / "schema_doc.min.js").exists()
 
 
+def test_generate_from_file_name_with_invalid_output_dir(tmp_path: Path) -> None:
+    """Test generating from file names for input and output where the output directory is absent"""
+    test_case_path = get_test_case_path("basic")
+    result_path = tmp_path / "nonsense" / "result_with_another_name.html"
+
+    with pytest.raises(FileNotFoundError) as exception_info:
+        generate_from_filename(test_case_path, str(result_path.resolve()), False, False, False, False)
+        assert f"{os.path.dirname(result_path)} not found" in str(exception_info.value)
+
+
+def test_generate_from_file_name_with_invalid_output_dir_and_no_resource_copy(tmp_path: Path) -> None:
+    """Test generating from file names for input and output where the output directory is absent"""
+    test_case_path = get_test_case_path("basic")
+    result_path = tmp_path / "nonsense" / "result_with_another_name.html"
+
+    with pytest.raises(FileNotFoundError) as exception_info:
+        generate_from_filename(test_case_path, str(result_path.resolve()), False, False, False, False, False, False)
+        assert f"{os.path.dirname(result_path)} not found" in str(exception_info.value)
+
+
 def _assert_deprecation_message(caplog: LogCaptureFixture, must_be_present: bool) -> None:
     log_records = [r.message for r in caplog.records]
     if must_be_present:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,11 @@ def get_test_case_path(name: str) -> str:
     return os.path.realpath(os.path.join(parent_dir, "docs", "examples", "cases", f"{name}.json"))
 
 
+def get_nonexistent_output_path(name: str) -> str:
+    """Get the location of a non-existent output file"""
+    return os.path.realpath(os.path.join(parent_dir, "not", "a", "path", f"{name}.html"))
+
+
 def generate_case(case_name: str, config: GenerationConfiguration = None) -> BeautifulSoup:
     """Get the BeautifulSoup object for a test case"""
     return BeautifulSoup(


### PR DESCRIPTION
Closes #97 

- Throw FileNotFoundError if output directory is invalid
- Catch and rethrow as ClickException in main()
- Add tests for cli and for specific functions