### PR TITLE
fix: Fix yaml example in md template

### DIFF
--- a/json_schema_for_humans/generation_configuration.py
+++ b/json_schema_for_humans/generation_configuration.py
@@ -86,7 +86,7 @@ class GenerationConfiguration:
     def result_extension(self) -> str:
         """File extension for the resulting documentation"""
         if self.custom_template_path:
-            return os.path.splitext(self.custom_template_path)[1]
+            return Path(self.custom_template_path).suffix[1:]
 
         if self.template_name:
             return DocumentationTemplate(self.template_name).result_extension

--- a/json_schema_for_humans/jinja_filters.py
+++ b/json_schema_for_humans/jinja_filters.py
@@ -217,8 +217,11 @@ def highlight_json_example(example_text: str) -> str:
     """Filter. Return an highlighted version of the provided JSON text"""
     return highlight(example_text, JavascriptLexer(), HtmlFormatter())
 
-
-def highlight_yaml_example(example_text: str) -> str:
+def yaml_example(example_text: str) -> str:
     """Filter. Return a YAML version of the provided JSON text"""
     yaml_text = yaml.dump(json.loads(example_text), allow_unicode=True)
-    return highlight(yaml_text, YamlLexer(), HtmlFormatter())
+    return yaml_text
+
+def highlight_yaml_example(example_text: str) -> str:
+    """Filter. Return a highlighted YAML version of the provided JSON text"""
+    return highlight(yaml_example(example_text), YamlLexer(), HtmlFormatter())

--- a/json_schema_for_humans/template_renderer.py
+++ b/json_schema_for_humans/template_renderer.py
@@ -54,6 +54,7 @@ class TemplateRenderer:
         env.filters["get_undocumented_required_properties"] = jinja_filters.get_undocumented_required_properties
         env.filters["highlight_json_example"] = jinja_filters.highlight_json_example
         env.filters["highlight_yaml_example"] = jinja_filters.highlight_yaml_example
+        env.filters["yaml_example"] = jinja_filters.yaml_example
         env.filters["first_line"] = jinja_filters.first_line
 
         env.tests["combining"] = jinja_filters.is_combining

--- a/json_schema_for_humans/templates/md/section_examples.md
+++ b/json_schema_for_humans/templates/md/section_examples.md
@@ -9,7 +9,7 @@
         {{- "\n" }}```
     {%- else -%}
         {{- "" }}```yaml
-        {{- "\n" }}{{ example | highlight_yaml_example }}
+        {{- "\n" }}{{ example | yaml_example }}
         {{- "\n" }}```
     {%- endif -%}
     {{ "\n" }}


### PR DESCRIPTION
This PR aims to fix the `md` template when `examples_as_yaml` is enabled.

In the current situation, this would render HTML, which is not compatible with (for example) the GitHub Markdown renderer.
This PR would render the yaml as-is.

It also fixes an issue where the file extension for custom templates would be returned as `.md` instead of `md`.