### PR TITLE
Handle urlencoded characters in anchor refs

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -2934,5 +2934,63 @@ the description of an attribute
 [examples/examples_md_nested_with_badges/with_special_chars.md](examples/examples_md_nested_with_badges/with_special_chars.md ':include')
 </details>
 
+## --with_urlencoded_anchor--
+### with_urlencoded_anchor
+
+
+<details>
+<summary>Json schema - Click here to expand source code...</summary>
+
+[examples/cases/with_urlencoded_anchor.json](examples/cases/with_urlencoded_anchor.json ':include :type=code')
+</details>
+
+
+<details>
+<summary>JS template - Click here to expand the rendered result...</summary>
+<a href="https://coveooss.github.io/json-schema-for-humans/examples/examples_js_default/with_urlencoded_anchor.html" target="_blank">Open it in full page</a>
+
+[examples/examples_js_default/with_urlencoded_anchor.html](examples/examples_js_default/with_urlencoded_anchor.html ':include :type=iframe width=100% height=400px')
+</details>
+
+
+<details>
+<summary>Flat template - Click here to expand the rendered result...</summary>
+<a href="https://coveooss.github.io/json-schema-for-humans/examples/examples_flat_default/with_urlencoded_anchor.html" target="_blank">Open it in full page</a>
+
+[examples/examples_flat_default/with_urlencoded_anchor.html](examples/examples_flat_default/with_urlencoded_anchor.html ':include :type=iframe width=100% height=400px')
+</details>
+
+
+<details>
+<summary>Markdown without badge template - Click here to expand the rendered result...</summary>
+<a href="https://github.com/coveooss/json-schema-for-humans/blob/main/docs/examples/examples_md_default/with_urlencoded_anchor.md" target="_blank">Open it in github</a>
+
+[examples/examples_md_default/with_urlencoded_anchor.md](examples/examples_md_default/with_urlencoded_anchor.md ':include')
+</details>
+
+
+<details>
+<summary>Markdown with badges template - Click here to expand the rendered result...</summary>
+<a href="https://github.com/coveooss/json-schema-for-humans/blob/main/docs/examples/examples_md_with_badges/with_urlencoded_anchor.md" target="_blank">Open it in github</a>
+
+[examples/examples_md_with_badges/with_urlencoded_anchor.md](examples/examples_md_with_badges/with_urlencoded_anchor.md ':include')
+</details>
+
+
+<details>
+<summary>Nested Markdown without badges template - Click here to expand the rendered result...</summary>
+<a href="https://github.com/coveooss/json-schema-for-humans/blob/main/docs/examples/examples_md_nested_default/with_urlencoded_anchor.md" target="_blank">Open it in github</a>
+
+[examples/examples_md_nested_default/with_urlencoded_anchor.md](examples/examples_md_nested_default/with_urlencoded_anchor.md ':include')
+</details>
+
+
+<details>
+<summary>Nested Markdown with badges template - Click here to expand the rendered result...</summary>
+<a href="https://github.com/coveooss/json-schema-for-humans/blob/main/docs/examples/examples_md_nested_with_badges/with_urlencoded_anchor.md" target="_blank">Open it in github</a>
+
+[examples/examples_md_nested_with_badges/with_urlencoded_anchor.md](examples/examples_md_nested_with_badges/with_urlencoded_anchor.md ':include')
+</details>
+
 
 <!-- select:end -->

--- a/docs/examples/cases/with_urlencoded_anchor.json
+++ b/docs/examples/cases/with_urlencoded_anchor.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "dss2-SigningTimeInfoType": {
+      "$xsd-type": "SigningTimeInfoType",
+      "$xsd-full-type": "dss2:SigningTimeInfoType",
+      "type": "object",
+      "properties": {
+        "signingTime": {
+          "type": "integer",
+          "format": "utc-millisec"
+        },
+        "signingTimeBounds": {
+          "$ref": "#/definitions/dss2-SigningTimeInfoType%3ASigningTimeBoundaries"
+        }
+      },
+      "required": [
+        "signingTime"
+      ]
+    },
+    "dss2-SigningTimeInfoType:SigningTimeBoundaries": {
+      "$xsd-type": "",
+      "$xsd-full-type": "",
+      "type": "object",
+      "properties": {
+        "lowerBound": {
+          "type": "integer",
+          "format": "utc-millisec"
+        },
+        "upperBound": {
+          "type": "integer",
+          "format": "utc-millisec"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "signingTimeInfo": {
+      "$ref": "#/definitions/dss2-SigningTimeInfoType"
+    }
+  }
+}

--- a/docs/examples/examples_flat_default/with_urlencoded_anchor.html
+++ b/docs/examples/examples_flat_default/with_urlencoded_anchor.html
@@ -1,0 +1,268 @@
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Overpass:300,400,600,800">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+	<link rel="stylesheet" type="text/css" href="schema_doc.css">
+    <meta charset="utf-8"/>
+    <title>Schema Docs</title>
+</head>
+<body id="root">
+
+    <div class="breadcrumbs"></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+
+
+
+
+
+
+
+
+
+
+
+            
+
+            
+            
+
+            
+
+<div class="card">
+    <div class="card-header" id="signingTimeInfo">
+        <h2 class="mb-0">
+            <a href="#signingTimeInfo"><span class="property-name">signingTimeInfo</span></a></h2>
+    </div>
+
+    <div class="card-body property-definition-div">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo">signingTimeInfo</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+            
+
+            
+            
+
+            
+
+<div class="card">
+    <div class="card-header" id="signingTimeInfo_signingTime">
+        <h2 class="mb-0">
+            <a href="#signingTimeInfo_signingTime"><span class="property-name">signingTime</span></a> <span class="badge badge-warning required-property">Required</span></h2>
+    </div>
+
+    <div class="card-body property-definition-div">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo">signingTimeInfo</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTime">signingTime</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+
+
+
+
+
+
+
+
+
+
+
+
+            
+
+            
+            
+
+            
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header" id="signingTimeInfo_signingTimeBounds">
+        <h2 class="mb-0">
+            <a href="#signingTimeInfo_signingTimeBounds"><span class="property-name">signingTimeBounds</span></a></h2>
+    </div>
+
+    <div class="card-body property-definition-div">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo">signingTimeInfo</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds">signingTimeBounds</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+            
+
+            
+            
+
+            
+
+<div class="card">
+    <div class="card-header" id="signingTimeInfo_signingTimeBounds_lowerBound">
+        <h2 class="mb-0">
+            <a href="#signingTimeInfo_signingTimeBounds_lowerBound"><span class="property-name">lowerBound</span></a></h2>
+    </div>
+
+    <div class="card-body property-definition-div">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo">signingTimeInfo</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds">signingTimeBounds</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds_lowerBound">lowerBound</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+
+
+
+
+
+
+
+
+
+
+
+
+            
+
+            
+            
+
+            
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header" id="signingTimeInfo_signingTimeBounds_upperBound">
+        <h2 class="mb-0">
+            <a href="#signingTimeInfo_signingTimeBounds_upperBound"><span class="property-name">upperBound</span></a></h2>
+    </div>
+
+    <div class="card-body property-definition-div">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo">signingTimeInfo</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds">signingTimeBounds</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds_upperBound">upperBound</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+
+
+
+
+
+
+
+
+
+
+
+
+            
+
+            
+            
+
+            
+    </div>
+</div>
+    </div>
+</div>
+    </div>
+</div>
+
+    <footer>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a></p>
+    </footer></body>
+</html>

--- a/docs/examples/examples_js_default/with_urlencoded_anchor.html
+++ b/docs/examples/examples_js_default/with_urlencoded_anchor.html
@@ -1,0 +1,244 @@
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Overpass:300,400,600,800">
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+	<link rel="stylesheet" type="text/css" href="schema_doc.css">
+    <script src="https://use.fontawesome.com/facf9fa52c.js"></script>
+    <script src="schema_doc.min.js"></script>
+    <meta charset="utf-8"/>
+    <title>Schema Docs</title>
+</head>
+<body onload="anchorOnLoad();" id="root"><div class="text-right">
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".collapse:not(.show)" aria-expanded="false">Expand all</button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".collapse.show" aria-expanded="false">Collapse all</button>
+        </div>
+
+    <div class="breadcrumbs"></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+            
+
+            
+            
+
+            
+<div class="accordion" id="accordionsigningTimeInfo">
+    <div class="card">
+        <div class="card-header" id="headingsigningTimeInfo">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#signingTimeInfo"
+                        aria-expanded="" aria-controls="signingTimeInfo" onclick="setAnchor('#signingTimeInfo')"><span class="property-name">signingTimeInfo</span></button>
+            </h2>
+        </div>
+
+        <div id="signingTimeInfo"
+             class="collapse property-definition-div" aria-labelledby="headingsigningTimeInfo"
+             data-parent="#accordionsigningTimeInfo">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo" onclick="anchorLink('signingTimeInfo')">signingTimeInfo</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+
+    
+            
+
+            
+            
+
+            
+<div class="accordion" id="accordionsigningTimeInfo_signingTime">
+    <div class="card">
+        <div class="card-header" id="headingsigningTimeInfo_signingTime">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#signingTimeInfo_signingTime"
+                        aria-expanded="" aria-controls="signingTimeInfo_signingTime" onclick="setAnchor('#signingTimeInfo_signingTime')"><span class="property-name">signingTime</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="signingTimeInfo_signingTime"
+             class="collapse property-definition-div" aria-labelledby="headingsigningTimeInfo_signingTime"
+             data-parent="#accordionsigningTimeInfo_signingTime">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo" onclick="anchorLink('signingTimeInfo')">signingTimeInfo</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTime" onclick="anchorLink('signingTimeInfo_signingTime')">signingTime</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+
+            
+
+            
+            
+
+            
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsigningTimeInfo_signingTimeBounds">
+    <div class="card">
+        <div class="card-header" id="headingsigningTimeInfo_signingTimeBounds">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#signingTimeInfo_signingTimeBounds"
+                        aria-expanded="" aria-controls="signingTimeInfo_signingTimeBounds" onclick="setAnchor('#signingTimeInfo_signingTimeBounds')"><span class="property-name">signingTimeBounds</span></button>
+            </h2>
+        </div>
+
+        <div id="signingTimeInfo_signingTimeBounds"
+             class="collapse property-definition-div" aria-labelledby="headingsigningTimeInfo_signingTimeBounds"
+             data-parent="#accordionsigningTimeInfo_signingTimeBounds">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo" onclick="anchorLink('signingTimeInfo')">signingTimeInfo</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds" onclick="anchorLink('signingTimeInfo_signingTimeBounds')">signingTimeBounds</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+
+    
+            
+
+            
+            
+
+            
+<div class="accordion" id="accordionsigningTimeInfo_signingTimeBounds_lowerBound">
+    <div class="card">
+        <div class="card-header" id="headingsigningTimeInfo_signingTimeBounds_lowerBound">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#signingTimeInfo_signingTimeBounds_lowerBound"
+                        aria-expanded="" aria-controls="signingTimeInfo_signingTimeBounds_lowerBound" onclick="setAnchor('#signingTimeInfo_signingTimeBounds_lowerBound')"><span class="property-name">lowerBound</span></button>
+            </h2>
+        </div>
+
+        <div id="signingTimeInfo_signingTimeBounds_lowerBound"
+             class="collapse property-definition-div" aria-labelledby="headingsigningTimeInfo_signingTimeBounds_lowerBound"
+             data-parent="#accordionsigningTimeInfo_signingTimeBounds_lowerBound">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo" onclick="anchorLink('signingTimeInfo')">signingTimeInfo</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds" onclick="anchorLink('signingTimeInfo_signingTimeBounds')">signingTimeBounds</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds_lowerBound" onclick="anchorLink('signingTimeInfo_signingTimeBounds_lowerBound')">lowerBound</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+
+            
+
+            
+            
+
+            
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsigningTimeInfo_signingTimeBounds_upperBound">
+    <div class="card">
+        <div class="card-header" id="headingsigningTimeInfo_signingTimeBounds_upperBound">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#signingTimeInfo_signingTimeBounds_upperBound"
+                        aria-expanded="" aria-controls="signingTimeInfo_signingTimeBounds_upperBound" onclick="setAnchor('#signingTimeInfo_signingTimeBounds_upperBound')"><span class="property-name">upperBound</span></button>
+            </h2>
+        </div>
+
+        <div id="signingTimeInfo_signingTimeBounds_upperBound"
+             class="collapse property-definition-div" aria-labelledby="headingsigningTimeInfo_signingTimeBounds_upperBound"
+             data-parent="#accordionsigningTimeInfo_signingTimeBounds_upperBound">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo" onclick="anchorLink('signingTimeInfo')">signingTimeInfo</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds" onclick="anchorLink('signingTimeInfo_signingTimeBounds')">signingTimeBounds</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#signingTimeInfo_signingTimeBounds_upperBound" onclick="anchorLink('signingTimeInfo_signingTimeBounds_upperBound')">upperBound</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+
+            
+
+            
+            
+
+            
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+    <footer>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a></p>
+    </footer></body>
+</html>

--- a/docs/examples/examples_md_default/with_urlencoded_anchor.md
+++ b/docs/examples/examples_md_default/with_urlencoded_anchor.md
@@ -1,0 +1,69 @@
+# Schema Docs
+
+- [1. [Optional] Property `root > signingTimeInfo`](#signingTimeInfo)
+  - [1.1. [Required] Property `root > signingTimeInfo > signingTime`](#signingTimeInfo_signingTime)
+  - [1.2. [Optional] Property `root > signingTimeInfo > signingTimeBounds`](#signingTimeInfo_signingTimeBounds)
+    - [1.2.1. [Optional] Property `root > signingTimeInfo > signingTimeBounds > lowerBound`](#signingTimeInfo_signingTimeBounds_lowerBound)
+    - [1.2.2. [Optional] Property `root > signingTimeInfo > signingTimeBounds > upperBound`](#signingTimeInfo_signingTimeBounds_upperBound)
+
+| Type                      | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+| Property                               | Pattern | Type   | Deprecated | Definition                                | Title/Description |
+| -------------------------------------- | ------- | ------ | ---------- | ----------------------------------------- | ----------------- |
+| - [signingTimeInfo](#signingTimeInfo ) | No      | object | No         | In #/definitions/dss2-SigningTimeInfoType | -                 |
+|                                        |         |        |            |                                           |                   |
+
+## <a name="signingTimeInfo"></a>1. [Optional] Property `root > signingTimeInfo`
+
+| Type                      | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+| **Defined in**            | #/definitions/dss2-SigningTimeInfoType                                    |
+|                           |                                                                           |
+
+| Property                                                   | Pattern | Type    | Deprecated | Definition                                                        | Title/Description |
+| ---------------------------------------------------------- | ------- | ------- | ---------- | ----------------------------------------------------------------- | ----------------- |
+| + [signingTime](#signingTimeInfo_signingTime )             | No      | integer | No         | -                                                                 | -                 |
+| - [signingTimeBounds](#signingTimeInfo_signingTimeBounds ) | No      | object  | No         | In #/definitions/dss2-SigningTimeInfoType%3ASigningTimeBoundaries | -                 |
+|                                                            |         |         |            |                                                                   |                   |
+
+### <a name="signingTimeInfo_signingTime"></a>1.1. [Required] Property `root > signingTimeInfo > signingTime`
+
+| Type                      | `integer`                                                                 |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+### <a name="signingTimeInfo_signingTimeBounds"></a>1.2. [Optional] Property `root > signingTimeInfo > signingTimeBounds`
+
+| Type                      | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+| **Defined in**            | #/definitions/dss2-SigningTimeInfoType%3ASigningTimeBoundaries            |
+|                           |                                                                           |
+
+| Property                                                       | Pattern | Type    | Deprecated | Definition | Title/Description |
+| -------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [lowerBound](#signingTimeInfo_signingTimeBounds_lowerBound ) | No      | integer | No         | -          | -                 |
+| - [upperBound](#signingTimeInfo_signingTimeBounds_upperBound ) | No      | integer | No         | -          | -                 |
+|                                                                |         |         |            |            |                   |
+
+#### <a name="signingTimeInfo_signingTimeBounds_lowerBound"></a>1.2.1. [Optional] Property `root > signingTimeInfo > signingTimeBounds > lowerBound`
+
+| Type                      | `integer`                                                                 |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+#### <a name="signingTimeInfo_signingTimeBounds_upperBound"></a>1.2.2. [Optional] Property `root > signingTimeInfo > signingTimeBounds > upperBound`
+
+| Type                      | `integer`                                                                 |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+----------------------------------------------------------------------------------------------------------------------------
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)

--- a/docs/examples/examples_md_nested_default/with_urlencoded_anchor.md
+++ b/docs/examples/examples_md_nested_default/with_urlencoded_anchor.md
@@ -1,0 +1,87 @@
+# Schema Docs
+
+- [1. [Optional] Property root > signingTimeInfo](#signingTimeInfo)
+  - [1.1. [Required] Property root > signingTimeInfo > signingTime](#signingTimeInfo_signingTime)
+  - [1.2. [Optional] Property root > signingTimeInfo > signingTimeBounds](#signingTimeInfo_signingTimeBounds)
+    - [1.2.1. [Optional] Property root > signingTimeInfo > signingTimeBounds > lowerBound](#signingTimeInfo_signingTimeBounds_lowerBound)
+    - [1.2.2. [Optional] Property root > signingTimeInfo > signingTimeBounds > upperBound](#signingTimeInfo_signingTimeBounds_upperBound)
+
+| Type                      | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+<details>
+<summary><strong> <a name="signingTimeInfo"></a>1. [Optional] Property root > signingTimeInfo</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+| **Defined in**            | #/definitions/dss2-SigningTimeInfoType                                    |
+|                           |                                                                           |
+
+<details>
+<summary><strong> <a name="signingTimeInfo_signingTime"></a>1.1. [Required] Property root > signingTimeInfo > signingTime</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `integer`                                                                 |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+</blockquote>
+</details>
+
+<details>
+<summary><strong> <a name="signingTimeInfo_signingTimeBounds"></a>1.2. [Optional] Property root > signingTimeInfo > signingTimeBounds</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+| **Defined in**            | #/definitions/dss2-SigningTimeInfoType%3ASigningTimeBoundaries            |
+|                           |                                                                           |
+
+<details>
+<summary><strong> <a name="signingTimeInfo_signingTimeBounds_lowerBound"></a>1.2.1. [Optional] Property root > signingTimeInfo > signingTimeBounds > lowerBound</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `integer`                                                                 |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+</blockquote>
+</details>
+
+<details>
+<summary><strong> <a name="signingTimeInfo_signingTimeBounds_upperBound"></a>1.2.2. [Optional] Property root > signingTimeInfo > signingTimeBounds > upperBound</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `integer`                                                                 |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+|                           |                                                                           |
+
+</blockquote>
+</details>
+
+</blockquote>
+</details>
+
+</blockquote>
+</details>
+
+----------------------------------------------------------------------------------------------------------------------------
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)

--- a/docs/examples/examples_md_nested_with_badges/with_urlencoded_anchor.md
+++ b/docs/examples/examples_md_nested_with_badges/with_urlencoded_anchor.md
@@ -1,0 +1,87 @@
+# Schema Docs
+
+- [1. [Optional] Property root > signingTimeInfo](#signingTimeInfo)
+  - [1.1. [Required] Property root > signingTimeInfo > signingTime](#signingTimeInfo_signingTime)
+  - [1.2. [Optional] Property root > signingTimeInfo > signingTimeBounds](#signingTimeInfo_signingTimeBounds)
+    - [1.2.1. [Optional] Property root > signingTimeInfo > signingTimeBounds > lowerBound](#signingTimeInfo_signingTimeBounds_lowerBound)
+    - [1.2.2. [Optional] Property root > signingTimeInfo > signingTimeBounds > upperBound](#signingTimeInfo_signingTimeBounds_upperBound)
+
+| Type                      | `object`                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+|                           |                                                                                                                     |
+
+<details>
+<summary><strong> <a name="signingTimeInfo"></a>1. [Optional] Property root > signingTimeInfo</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `object`                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+| **Defined in**            | #/definitions/dss2-SigningTimeInfoType                                                                              |
+|                           |                                                                                                                     |
+
+<details>
+<summary><strong> <a name="signingTimeInfo_signingTime"></a>1.1. [Required] Property root > signingTimeInfo > signingTime</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `integer`                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+|                           |                                                                                                                     |
+
+</blockquote>
+</details>
+
+<details>
+<summary><strong> <a name="signingTimeInfo_signingTimeBounds"></a>1.2. [Optional] Property root > signingTimeInfo > signingTimeBounds</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `object`                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+| **Defined in**            | #/definitions/dss2-SigningTimeInfoType%3ASigningTimeBoundaries                                                      |
+|                           |                                                                                                                     |
+
+<details>
+<summary><strong> <a name="signingTimeInfo_signingTimeBounds_lowerBound"></a>1.2.1. [Optional] Property root > signingTimeInfo > signingTimeBounds > lowerBound</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `integer`                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+|                           |                                                                                                                     |
+
+</blockquote>
+</details>
+
+<details>
+<summary><strong> <a name="signingTimeInfo_signingTimeBounds_upperBound"></a>1.2.2. [Optional] Property root > signingTimeInfo > signingTimeBounds > upperBound</strong>  
+
+</summary>
+<blockquote>
+
+| Type                      | `integer`                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+|                           |                                                                                                                     |
+
+</blockquote>
+</details>
+
+</blockquote>
+</details>
+
+</blockquote>
+</details>
+
+----------------------------------------------------------------------------------------------------------------------------
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)

--- a/docs/examples/examples_md_with_badges/with_urlencoded_anchor.md
+++ b/docs/examples/examples_md_with_badges/with_urlencoded_anchor.md
@@ -1,0 +1,69 @@
+# Schema Docs
+
+- [1. ![badge](https://img.shields.io/badge/Optional-yellow) Property `root > signingTimeInfo`](#signingTimeInfo)
+  - [1.1. ![badge](https://img.shields.io/badge/Required-blue) Property `root > signingTimeInfo > signingTime`](#signingTimeInfo_signingTime)
+  - [1.2. ![badge](https://img.shields.io/badge/Optional-yellow) Property `root > signingTimeInfo > signingTimeBounds`](#signingTimeInfo_signingTimeBounds)
+    - [1.2.1. ![badge](https://img.shields.io/badge/Optional-yellow) Property `root > signingTimeInfo > signingTimeBounds > lowerBound`](#signingTimeInfo_signingTimeBounds_lowerBound)
+    - [1.2.2. ![badge](https://img.shields.io/badge/Optional-yellow) Property `root > signingTimeInfo > signingTimeBounds > upperBound`](#signingTimeInfo_signingTimeBounds_upperBound)
+
+| Type                      | `object`                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+|                           |                                                                                                                     |
+
+| Property                               | Pattern | Type   | Deprecated | Definition                                | Title/Description |
+| -------------------------------------- | ------- | ------ | ---------- | ----------------------------------------- | ----------------- |
+| - [signingTimeInfo](#signingTimeInfo ) | No      | object | No         | In #/definitions/dss2-SigningTimeInfoType | -                 |
+|                                        |         |        |            |                                           |                   |
+
+## <a name="signingTimeInfo"></a>1. ![badge](https://img.shields.io/badge/Optional-yellow) Property `root > signingTimeInfo`
+
+| Type                      | `object`                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+| **Defined in**            | #/definitions/dss2-SigningTimeInfoType                                                                              |
+|                           |                                                                                                                     |
+
+| Property                                                   | Pattern | Type    | Deprecated | Definition                                                        | Title/Description |
+| ---------------------------------------------------------- | ------- | ------- | ---------- | ----------------------------------------------------------------- | ----------------- |
+| + [signingTime](#signingTimeInfo_signingTime )             | No      | integer | No         | -                                                                 | -                 |
+| - [signingTimeBounds](#signingTimeInfo_signingTimeBounds ) | No      | object  | No         | In #/definitions/dss2-SigningTimeInfoType%3ASigningTimeBoundaries | -                 |
+|                                                            |         |         |            |                                                                   |                   |
+
+### <a name="signingTimeInfo_signingTime"></a>1.1. ![badge](https://img.shields.io/badge/Required-blue) Property `root > signingTimeInfo > signingTime`
+
+| Type                      | `integer`                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+|                           |                                                                                                                     |
+
+### <a name="signingTimeInfo_signingTimeBounds"></a>1.2. ![badge](https://img.shields.io/badge/Optional-yellow) Property `root > signingTimeInfo > signingTimeBounds`
+
+| Type                      | `object`                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+| **Defined in**            | #/definitions/dss2-SigningTimeInfoType%3ASigningTimeBoundaries                                                      |
+|                           |                                                                                                                     |
+
+| Property                                                       | Pattern | Type    | Deprecated | Definition | Title/Description |
+| -------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| - [lowerBound](#signingTimeInfo_signingTimeBounds_lowerBound ) | No      | integer | No         | -          | -                 |
+| - [upperBound](#signingTimeInfo_signingTimeBounds_upperBound ) | No      | integer | No         | -          | -                 |
+|                                                                |         |         |            |            |                   |
+
+#### <a name="signingTimeInfo_signingTimeBounds_lowerBound"></a>1.2.1. ![badge](https://img.shields.io/badge/Optional-yellow) Property `root > signingTimeInfo > signingTimeBounds > lowerBound`
+
+| Type                      | `integer`                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+|                           |                                                                                                                     |
+
+#### <a name="signingTimeInfo_signingTimeBounds_upperBound"></a>1.2.2. ![badge](https://img.shields.io/badge/Optional-yellow) Property `root > signingTimeInfo > signingTimeBounds > upperBound`
+
+| Type                      | `integer`                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Additional properties** | [![badge](https://img.shields.io/badge/Any+type-allowed-green)](# "Additional Properties of any type are allowed.") |
+|                           |                                                                                                                     |
+
+----------------------------------------------------------------------------------------------------------------------------
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)

--- a/json_schema_for_humans/schema/intermediate_representation.py
+++ b/json_schema_for_humans/schema/intermediate_representation.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import urllib.parse
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -216,6 +217,7 @@ def _resolve_ref(
         anchor_part = ROOT_ID
     else:
         uri_part, anchor_part = reference_path.split("#", maxsplit=1)
+        anchor_part = urllib.parse.unquote(anchor_part)
         anchor_part = anchor_part.strip("/") or ROOT_ID  # Special case for the root schema
 
     # Resolve file path portion of reference

--- a/tests/generate_test.py
+++ b/tests/generate_test.py
@@ -405,6 +405,14 @@ def test_with_examples() -> None:
     ]
 
 
+def test_with_urlencoded_anchor() -> None:
+    soup = generate_case("with_urlencoded_anchor")
+    property_names = soup.find_all("span", class_=["property-name"])
+    property_names_text = [pn.text for pn in property_names]
+    assert "lowerBound" in property_names_text
+    assert "upperBound" in property_names_text
+
+
 def test_with_yaml_examples() -> None:
     soup = generate_case("with_examples", GenerationConfiguration(examples_as_yaml=True))
 


### PR DESCRIPTION
In version 0.39.5 trying to rener a schema like

https://json.schemastore.org/dss-2.0.0.json or
https://json.schemastore.org/opspec-io-0.1.7.json

throws a KeyError e.g: `KeyError: 'dss2-SigningTimeInfoType%3ASigningTimeBoundaries'`

because the anchor ref is URL Encoded but the JSON keys aren't.

This PR fixes the issue and I've added an example/test case based on stripping down https://json.schemastore.org/dss-2.0.0.json to a minimal case.

Hopefully I've followed all the contributing guidelines correctly :crossed_fingers: 