### PR TITLE
Deprecate py36

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are more than welcome! Don't hesitate to open an incomplete PR to 
 
 ## Python versions
 
-The library currently supports Python versions 3.6+
+The library currently supports Python versions 3.7+
 
 ## Install dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.7"
 click = "^8.0.1"
 dataclasses = { version = "^0.6", python = "<3.7" }
 dataclasses-json = "^0.5.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.7"
 click = "^8.0.1"
-dataclasses = { version = "^0.6", python = "<3.7" }
 dataclasses-json = "^0.5.6"
 htmlmin = "^0.1.12"
 Jinja2 = ">3"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.6,3.7,3.8,3.9,3.10}
+envlist = py{3.7,3.8,3.9,3.10}
 requires =
     tox-poetry-dev-dependencies
 isolated_build = True


### PR DESCRIPTION
The build is broken on Python 3.6. This version is end of life, so let's remove it.