### PR TITLE
Do not sort YAML keys in examples

### DIFF
--- a/json_schema_for_humans/jinja_filters.py
+++ b/json_schema_for_humans/jinja_filters.py
@@ -220,7 +220,7 @@ def highlight_json_example(example_text: str) -> str:
 
 def yaml_example(example_text: str) -> str:
     """Filter. Return a YAML version of the provided JSON text"""
-    yaml_text = yaml.dump(json.loads(example_text), allow_unicode=True)
+    yaml_text = yaml.dump(json.loads(example_text), allow_unicode=True, sort_keys=False)
     return yaml_text
 
 

--- a/tests/generate_test.py
+++ b/tests/generate_test.py
@@ -310,7 +310,9 @@ def test_deprecated_in_description() -> None:
     """Test finding whether a property is deprecated from its description"""
     soup = generate_case("deprecated", GenerationConfiguration(deprecated_from_description=True))
 
-    tests.html_schema_doc_asserts.assert_property_names(soup, ["deprecated1", "deprecated2", 'deprecated3', 'deprecated4', "not_deprecated"])
+    tests.html_schema_doc_asserts.assert_property_names(
+        soup, ["deprecated1", "deprecated2", "deprecated3", "deprecated4", "not_deprecated"]
+    )
     tests.html_schema_doc_asserts.assert_deprecated(soup, [True, True, True, True, False])
 
 


### PR DESCRIPTION
YAML examples will have the keys in objects sorted, which differs to the behavior of the JSON examples. Adding `sort_keys=False` makes the YAML examples match the JSON examples.

<table>
<tr>
<th>Source</th>
<th>JSON</th>
<th>YAML Before</th>
<th>YAML After</th>
</tr>
<tr>
<td>

```json
"examples": [
    {
        "z": 1,
        "y": 2,
        "x": 3
    }
]
```

</td>
<td>

```json
  {
      "z": 1,
      "y": 2,
      "x": 3
  }
```

</td>
<td>

```yaml
x: 3,
y: 2,
z: 1
```

</td>
<td>

```yaml
z: 1
y: 2
x: 3
```

</td>
</tr>
</table>

</table>
</table>

