### PR TITLE
Fix a typing error

### DIFF
--- a/json_schema_for_humans/md_template.py
+++ b/json_schema_for_humans/md_template.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 from urllib.parse import quote_plus, quote
 
 import jinja2
@@ -32,8 +32,10 @@ def get_numeric_maximum_restriction(schema_node: SchemaNode, default: str = "N/A
     return maximum_fragment
 
 
-def escape_for_table(example_text: str) -> str:
+def escape_for_table(example_text: Optional[str]) -> str:
     """Filter. escape characters('|', '`') in string to be inserted into markdown table"""
+    if example_text is None:
+        return ""
     return example_text.translate(str.maketrans({"|": "\\|", "`": "\\`"}))
 
 
@@ -316,7 +318,7 @@ class MarkdownTemplate(object):
         """
         properties = []
         for sub_property in schema.iterate_properties:
-            line = []
+            line: List[str] = []
             # property name
             property_name = "+ " if sub_property.is_required_property else "- "
             property_name += self.format_link(escape_for_table(sub_property.property_name), sub_property.html_id)


### PR DESCRIPTION
In md_template.properties_table, we call:

    escape_for_table(sub_property.property_name)

`sub_property` is a `SchemaNode`, making `property_name` an
`Optional[str]`.

`escape_for_table` expected `str` as input. Adjust it to accept
`Optional[str]`.