### PR TITLE
fix(md): Correct non-breadcrumb array item headings

### DIFF
--- a/json_schema_for_humans/templates/md/breadcrumbs.md
+++ b/json_schema_for_humans/templates/md/breadcrumbs.md
@@ -4,6 +4,10 @@
     {{ node.name_for_breadcrumbs }}{%- if not loop.last %} > {% endif -%}
   {%- endfor -%}
 {%- else -%}
-  {{- schema.property_name -}}
+  {%- if schema.property_name -%}
+    {{- schema.property_name -}}
+  {%- else -%}
+    {{ schema.name_for_breadcrumbs }}
+  {%- endif -%}
 {% endif %}
 {% endfilter %}

--- a/json_schema_for_humans/templates/md/breadcrumbs.md
+++ b/json_schema_for_humans/templates/md/breadcrumbs.md
@@ -4,10 +4,6 @@
     {{ node.name_for_breadcrumbs }}{%- if not loop.last %} > {% endif -%}
   {%- endfor -%}
 {%- else -%}
-  {%- if schema.property_name -%}
-    {{- schema.property_name -}}
-  {%- else -%}
-    {{ schema.name_for_breadcrumbs }}
-  {%- endif -%}
+  {{ schema.name_for_breadcrumbs }}
 {% endif %}
 {% endfilter %}


### PR DESCRIPTION
Previously array item headings would show as "None" when breadcrumbs
were disabled. Now they show the correct trailing value "<array> items".

Example:

```diff
-  - [7.1. None](#autogenerated_heading_2)
+  - [7.1. rds items](#autogenerated_heading_2)
```