### PR TITLE
Fix <br /> in headings without breadcrumbs

### DIFF
--- a/json_schema_for_humans/templates/md/breadcrumbs.md
+++ b/json_schema_for_humans/templates/md/breadcrumbs.md
@@ -1,9 +1,9 @@
-{% filter md_escape_for_table %}
-{%- if config.show_breadcrumbs %}
+{%- filter md_escape_for_table -%}
+{%- if config.show_breadcrumbs -%}
   {%- for node in schema.nodes_from_root -%}
     {{ node.name_for_breadcrumbs }}{%- if not loop.last %} > {% endif -%}
   {%- endfor -%}
 {%- else -%}
   {{ schema.name_for_breadcrumbs }}
-{% endif %}
-{% endfilter %}
+{%- endif -%}
+{%- endfilter -%}


### PR DESCRIPTION
We were generating headings like:

```md
- [1. Property `version<br />`](#version)
```

Due to a spurious newline getting introduced in `breadcrumbs.md` when `config.show_breadcrumbs` was `False`.

It was added by line 7 specifically, eg the middle line here:

```jinja
{%- else -%}
  {{ schema.name_for_breadcrumbs }}
{% endif %}
```

And could be fixed by adding `-` to the start of the `endif` directive in above snippet only.

But for safety / consistency, add whitespace trimming to almost all directives in this template.