### PR TITLE
Fix test for $ref file schema 

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ These are **not** supported at the moment (PRs welcome!):
 References are supported:
 
 - To another part of the schema, e.g. `{ $ref: "#/definitions/something" }`
-- To a local file, `{"$ref": "references.json"}`, `{"$ref": "references.json#/definitions/something"}`
+- To a local file, `{"$ref": "references.json"}`, `{"$ref": "references.json#/definitions/something"}`, `{"$ref": "file://./references.json"}`, `{"$ref": "file://./references.json#/definitions/something}`
 - To a URL, `{"$ref": "http://example.com/schema.json"}`, `{"$ref": "http://example.com/schema.json#/definitions/something"}`
 
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ These are **not** supported at the moment (PRs welcome!):
 References are supported:
 
 - To another part of the schema, e.g. `{ $ref: "#/definitions/something" }`
-- To a local file, `{"$ref": "references.json"}`, `{"$ref": "references.json#/definitions/something"}`
+- To a local file, `{"$ref": "references.json"}`, `{"$ref": "references.json#/definitions/something"}`, `{"$ref": "file:references.json"}`, `{"$ref": "file:references.json#/definitions/something}`
 - To a URL, `{"$ref": "http://example.com/schema.json"}`, `{"$ref": "http://example.com/schema.json#/definitions/something"}`
 
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ These are **not** supported at the moment (PRs welcome!):
 References are supported:
 
 - To another part of the schema, e.g. `{ $ref: "#/definitions/something" }`
-- To a local file, `{"$ref": "references.json"}`, `{"$ref": "references.json#/definitions/something"}`, `{"$ref": "file://./references.json"}`, `{"$ref": "file://./references.json#/definitions/something}`
+- To a local file, `{"$ref": "references.json"}`, `{"$ref": "references.json#/definitions/something"}`
 - To a URL, `{"$ref": "http://example.com/schema.json"}`, `{"$ref": "http://example.com/schema.json#/definitions/something"}`
 
 

--- a/docs/examples/cases/references.json
+++ b/docs/examples/cases/references.json
@@ -40,7 +40,7 @@
       "$ref": "#/definitions/gift"
     },
     "file_prefix": {
-      "$ref": "file://./references.json#/definitions/gift"
+      "$ref": "#/definitions/gift"
     },
     "anchor_with_slash": {
       "$ref": "#/definitions/object_def"

--- a/docs/examples/cases/references.json
+++ b/docs/examples/cases/references.json
@@ -40,7 +40,7 @@
       "$ref": "#/definitions/gift"
     },
     "file_prefix": {
-      "$ref": "#/definitions/gift"
+      "$ref": "file://./references.json#/definitions/gift"
     },
     "anchor_with_slash": {
       "$ref": "#/definitions/object_def"

--- a/docs/examples/cases/references.json
+++ b/docs/examples/cases/references.json
@@ -40,7 +40,7 @@
       "$ref": "#/definitions/gift"
     },
     "file_prefix": {
-      "$ref": "#/definitions/gift"
+      "$ref": "file:references.json#/definitions/gift"
     },
     "anchor_with_slash": {
       "$ref": "#/definitions/object_def"

--- a/json_schema_for_humans/schema/intermediate_representation.py
+++ b/json_schema_for_humans/schema/intermediate_representation.py
@@ -264,14 +264,14 @@ def _resolve_ref(
     if uri_part:
         if uri_part.startswith("http"):
             referenced_schema_path = uri_part
-        elif uri_part.startswith("file:"):
-            referenced_schema_path = os.path.realpath(os.path.join(os.path.dirname(current_node.file), uri_part[5:]))
+        elif uri_part.startswith("file://"):
+            referenced_schema_path = os.path.realpath(os.path.join(os.path.dirname(current_node.file), uri_part[7:]))
         else:
             referenced_schema_path = os.path.realpath(os.path.join(os.path.dirname(current_node.file), uri_part))
     elif current_node.file.startswith("http"):
         referenced_schema_path = current_node.file
-    elif current_node.file.startswith("file:"):
-        referenced_schema_path = os.path.realpath(current_node.file[5:])
+    elif current_node.file.startswith("file://"):
+        referenced_schema_path = os.path.realpath(current_node.file[7:])
     else:
         referenced_schema_path = os.path.realpath(current_node.file)
 

--- a/json_schema_for_humans/schema/intermediate_representation.py
+++ b/json_schema_for_humans/schema/intermediate_representation.py
@@ -264,14 +264,14 @@ def _resolve_ref(
     if uri_part:
         if uri_part.startswith("http"):
             referenced_schema_path = uri_part
-        elif uri_part.startswith("file://"):
-            referenced_schema_path = os.path.realpath(os.path.join(os.path.dirname(current_node.file), uri_part[7:]))
+        elif uri_part.startswith("file:"):
+            referenced_schema_path = os.path.realpath(os.path.join(os.path.dirname(current_node.file), uri_part[5:]))
         else:
             referenced_schema_path = os.path.realpath(os.path.join(os.path.dirname(current_node.file), uri_part))
     elif current_node.file.startswith("http"):
         referenced_schema_path = current_node.file
-    elif current_node.file.startswith("file://"):
-        referenced_schema_path = os.path.realpath(current_node.file[7:])
+    elif current_node.file.startswith("file:"):
+        referenced_schema_path = os.path.realpath(current_node.file[5:])
     else:
         referenced_schema_path = os.path.realpath(current_node.file)
 


### PR DESCRIPTION
The current implementation seems to support the format `file:./references.json`.
But looking at the [json schema specification](https://json-schema.org/draft/2020-12/json-schema-core.html#name-base-uri-anchors-and-derefe), it says that the $ref format follows RFC3986.
RFC 3986 says: (https://datatracker.ietf.org/doc/html/rfc3986#section-3)
```
       URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]

       hier-part = "//" authority path-abempty
                   /path-absolute
                   /path-rootless
                   /path-empty
```

In other words, shouldn't the format starting with "file:" be `file://./references.json` instead of `file:./references.json`?


As for the test, `file_prefix` was the same as `a_gift`, so I changed this.
https://github.com/coveooss/json-schema-for-humans/blob/6a467492d697c4a44a409409ab0391a4a4acd291/docs/examples/cases/references.json#L39-L44