### PR TITLE
Choose columns to be displayed in properties table in md template

### DIFF
--- a/json_schema_for_humans/generation_configuration.py
+++ b/json_schema_for_humans/generation_configuration.py
@@ -4,19 +4,19 @@ import os
 from dataclasses import dataclass
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Union, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import yaml
 from dataclasses_json import dataclass_json
 
 from json_schema_for_humans.const import (
-    DocumentationTemplate,
-    FileLikeType,
     DEFAULT_CSS_FILE_NAME,
     DEFAULT_JS_FILE_NAME,
     OFFLINE_CSS_FILE_NAMES,
     OFFLINE_FONT_FILE_NAMES,
     OFFLINE_JS_FILE_NAMES,
+    DocumentationTemplate,
+    FileLikeType,
 )
 
 
@@ -48,6 +48,14 @@ class GenerationConfiguration:
     template_md_options: Optional[Dict[str, Any]] = None
     with_footer: bool = True
     footer_show_time: bool = True
+    properties_table_columns: tuple[str] = (
+        "Property",
+        "Pattern",
+        "Type",
+        "Deprecated",
+        "Definition",
+        "Title/Description",
+    )
 
     def __post_init__(self) -> None:
         default_markdown_options = {

--- a/json_schema_for_humans/generation_configuration.py
+++ b/json_schema_for_humans/generation_configuration.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Tuple
 
 import yaml
 from dataclasses_json import dataclass_json
@@ -48,7 +48,7 @@ class GenerationConfiguration:
     template_md_options: Optional[Dict[str, Any]] = None
     with_footer: bool = True
     footer_show_time: bool = True
-    properties_table_columns: tuple[str] = (
+    properties_table_columns: Tuple[str] = (
         "Property",
         "Pattern",
         "Type",

--- a/json_schema_for_humans/md_template.py
+++ b/json_schema_for_humans/md_template.py
@@ -246,14 +246,14 @@ class MarkdownTemplate(object):
         if nested:
             menu = "<strong>"
 
-        # generate markdown title with anchor (except if depth 0)
+        # generate markdown title
         if depth == 0:
             menu += f" {title}"
         else:
             if self.config.template_md_options.get("show_heading_numbers"):
-                menu += f' <a name="{html_id}"></a>{heading_numbers} {title}'
+                menu += f" {heading_numbers} {title}"
             else:
-                menu += f' <a name="{html_id}"></a>{title}'
+                menu += f" {title}"
 
         # store current heading in toc
         toc_menu = f"[{title}](#{html_id})"
@@ -263,7 +263,12 @@ class MarkdownTemplate(object):
 
         if nested:
             menu += "</strong>"
-        return menu
+
+        if depth == 0:
+            return menu
+        else:
+            # Add anchor link
+            return f'<a name="{html_id}"></a>\n{menu}'
 
     def get_toc(self) -> str:
         """

--- a/json_schema_for_humans/md_template.py
+++ b/json_schema_for_humans/md_template.py
@@ -345,6 +345,9 @@ class MarkdownTemplate(object):
             else:
                 definition_info = "-"
 
+            if sub_property.property_name is None or not sub_property.property_name.strip():
+                continue
+
             header2value = {
                 "property": self.format_link(escape_for_table(sub_property.property_name), sub_property.html_id),
                 "required": "Yes" if sub_property.is_required_property else "No",

--- a/json_schema_for_humans/md_template.py
+++ b/json_schema_for_humans/md_template.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, List, Optional, Union
 from urllib.parse import quote, quote_plus
 
@@ -322,6 +323,7 @@ class MarkdownTemplate(object):
         Generate list of properties ready to be rendered by generate_table filter
         """
         properties = []
+        header = {}
         for sub_property in schema.iterate_properties:
             line: List[str] = []
 
@@ -355,13 +357,19 @@ class MarkdownTemplate(object):
             }
 
             for colname in self.config.properties_table_columns:
-                line.append(header2value[colname.lower()])
+                try:
+                    line.append(header2value[colname.lower()])
+                    header[colname.title()] = ""
+                except KeyError:
+                    logging.warning(
+                        "No value found for column '%s', passed in config 'properties_table_columns'. Ignoring.",
+                        colname,
+                    )
 
             properties.append(line)
 
-        if properties:
-            # Add header
-            properties.insert(0, [name.title() for name in self.config.properties_table_columns])
+        if header:
+            properties.insert(0, list(header))
 
         return properties
 

--- a/json_schema_for_humans/md_template.py
+++ b/json_schema_for_humans/md_template.py
@@ -354,6 +354,7 @@ class MarkdownTemplate(object):
                 else "No",
                 "definition": definition_info,
                 "title/description": escape_for_table(description),
+                "default": sub_property.default_value if sub_property.default_value is not None else "-",
             }
 
             for colname in self.config.properties_table_columns:

--- a/json_schema_for_humans/md_template.py
+++ b/json_schema_for_humans/md_template.py
@@ -291,7 +291,10 @@ class MarkdownTemplate(object):
     @staticmethod
     def format_link(title: str, link: str, tooltip: str = "") -> str:
         """Format a Markdown link"""
-        return f"[{title}](#{link} {tooltip})"
+        if tooltip:
+            return f"[{title}](#{link} {tooltip})"
+        else:
+            return f"[{title}](#{link})"
 
     def badge(self, name: str, color: str, value: str = "", show_text: bool = False, fallback: bool = True) -> str:
         """


### PR DESCRIPTION
Hello developers!

Thanks for this package, I found it recently and it has been very useful for me. Since this is my first PR here, I do apologise in anticipation for eventual deviations from the expected format (although I have read the contributing guidelines). The changes here are described below.

1. Add a config option `properties_table_columns` that can be used to choose the columns to be displayed in the properties tables, as well as the order in which they appear. For instance, one may write
  
    ```python
    config = GenerationConfiguration(
        template_name="md",
        properties_table_columns=[
            "property",
            "type",
            "required",
            "default",
            "title/description",
        ],
    )
    ```
    
    And the output property tables will have columns
    ```markdown
    | Property   | Type   | Required | Default | Title/Description  |
    ```
    
    The labels in the tables' headers are converted to title case.



3. As part of the process, and due to some tests I'm running in another project which uses this to publish docs to a page on Githib pages, I noticed that some entries without a name were being included in the properties table. I changed the code so that these were no longer added.


4. Another incidental change in this PR is to put anchor links on top of the headers. I found that having them insie the headers would cause duplication of the links in some cases (some templates use the headers to create menus, for instance), and then the links would no longer work as expected.

I am aware that this PR is failing the tests right now, because these changes produce results for the examples that are no longer identical to the expected ones. Would you be able to help me addressing these? I suspect you may already have some script to update the examples when doing changes that modify the expected outputs, so I thought it would be a good idea to ask first.