### PR TITLE
jinja_filters.py: Add escaping for unsafe input.

### DIFF
--- a/json_schema_for_humans/jinja_filters.py
+++ b/json_schema_for_humans/jinja_filters.py
@@ -7,7 +7,7 @@ from typing import List, Any
 
 from jinja2 import pass_environment, Environment
 from markdown2 import Markdown
-from markupsafe import Markup,escape as markupsafe_escape
+from markupsafe import Markup, escape as markupsafe_escape
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers.javascript import JavascriptLexer

--- a/json_schema_for_humans/jinja_filters.py
+++ b/json_schema_for_humans/jinja_filters.py
@@ -7,7 +7,7 @@ from typing import List, Any
 
 from jinja2 import pass_environment, Environment
 from markdown2 import Markdown
-from markupsafe import Markup
+from markupsafe import Markup,escape as markupsafe_escape
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers.javascript import JavascriptLexer
@@ -99,7 +99,7 @@ def get_description(env: Environment, schema_node: SchemaNode) -> str:
     if description and config.description_is_markdown and not config.result_extension == "md":
         # Markdown templates are expected to already have Markdown descriptions
         md: Markdown = env.globals["jsfh_md"]
-        description = Markup(md.convert(description))
+        description = Markup(md.convert(markupsafe_escape(description)))
 
     return description
 


### PR DESCRIPTION
E.g. if the description contains `<html>` tags this leads to issues.

`markupsafe.escape()` was the first HTML escaper to pop up, so I went with that.