### PR TITLE
Fix for unstable enum description templating_utils.py

### DIFF
--- a/json_schema_for_humans/templating_utils.py
+++ b/json_schema_for_humans/templating_utils.py
@@ -54,7 +54,7 @@ def get_type_name(schema_node: "SchemaNode") -> Optional[str]:
             for python_type_name in set(type(v.literal) for v in enum_values)
         ]
         if enum_type_names:
-            return f"{const.TYPE_ENUM} (of {' or '.join(enum_type_names)})"
+            return f"{const.TYPE_ENUM} (of {' or '.join(sorted(enum_type_names))})"
 
         return const.TYPE_ENUM
 


### PR DESCRIPTION
set is not ordered and may lead to not reproducible results between different python implementation. The root cause probably lays in different hash function implementation. 

Windows Python 3.10.11:
```
>>> set((type(None),str)) 
{<class 'NoneType'>, <class 'str'>}
```

Ubuntu Python 3.10.11
```
>>> set((type(None), str))
{<class 'str'>, <class 'NoneType'>}
```