### PR TITLE
Fix rendering of deprecated properties in MD

### DIFF
--- a/json_schema_for_humans/templates/md/section_properties_details.md
+++ b/json_schema_for_humans/templates/md/section_properties_details.md
@@ -12,8 +12,8 @@
       {%- if not skip_required and sub_property.property_name -%}
         {{ required_badge if sub_property.is_required_property else optional_badge -}}
       {%- endif -%}
-      {%- if sub_property is deprecated  -%}~~{%- endif -%}
-      {%- if sub_property.is_pattern_property %} Pattern{% endif %} Property `{% with schema=sub_property %}{%- include "breadcrumbs.md" %}{% endwith %}`
+      {%- if sub_property is deprecated  -%}~~ {%- endif -%}
+      {%- if sub_property.is_pattern_property %}Pattern {% endif %}Property `{% with schema=sub_property %}{%- include "breadcrumbs.md" %}{% endwith %}`
       {%- if sub_property is deprecated -%}~~{%- endif -%}
     {%- endfilter %}
   {%- endfilter %}

--- a/json_schema_for_humans/templates/md_nested/section_properties_details.md
+++ b/json_schema_for_humans/templates/md_nested/section_properties_details.md
@@ -13,8 +13,8 @@
       {%- if not skip_required and sub_property.property_name -%}
         {{ "[Required]" if sub_property.is_required_property else "[Optional]" -}}
       {%- endif -%}
-      {%- if sub_property is deprecated  -%}~~{%- endif -%}
-      {%- if sub_property.is_pattern_property %}Pattern{% endif %} Property {% with schema=sub_property %}{%- include "breadcrumbs.md" %}{% endwith %}
+      {%- if sub_property is deprecated  -%}~~ {%- endif -%}
+      {%- if sub_property.is_pattern_property %}Pattern {% endif %}Property {% with schema=sub_property %}{%- include "breadcrumbs.md" %}{% endwith %}
       {%- if sub_property is deprecated -%}~~{%- endif -%}
     {%- endfilter %}
   {%- endfilter %}


### PR DESCRIPTION
A leading whitespace prevents deprecated properties to be rendered strikedthrough in Markdown. This can be avoided by positioning the whitespace as trailing in the conditionals.

Fixes #294 