### PR TITLE
Support for Deprecated Keyword

### DIFF
--- a/json_schema_for_humans/schema/schema_keyword.py
+++ b/json_schema_for_humans/schema/schema_keyword.py
@@ -36,3 +36,4 @@ class SchemaKeyword(Enum):
     ADDITIONAL_PROPERTIES = "additionalProperties"
     FORMAT = "format"
     TYPE = "type"
+    DEPRECATED = "deprecated"

--- a/json_schema_for_humans/schema/schema_node.py
+++ b/json_schema_for_humans/schema/schema_node.py
@@ -375,6 +375,10 @@ class SchemaNode:
         return self.get_keyword(SchemaKeyword.PROPERTIES)
 
     @property
+    def kw_deprecated(self) -> Optional["SchemaNode"]:
+        return self.get_keyword(SchemaKeyword.DEPRECATED)
+    
+    @property
     def kw_pattern_properties(self) -> Optional["SchemaNode"]:
         return self.get_keyword(SchemaKeyword.PATTERN_PROPERTIES)
 

--- a/json_schema_for_humans/templates/js/section_properties.html
+++ b/json_schema_for_humans/templates/js/section_properties.html
@@ -16,7 +16,7 @@
                     {%- if sub_property.is_required_property -%}
                         {{ " " }}<span class="badge badge-warning required-property">Required</span>
                     {%- endif -%}
-                    {%- if sub_property is deprecated -%}
+                    {%- if sub_property.kw_deprecated -%}
                         {{ " " }}<span class="badge badge-danger deprecated-property">Deprecated</span>
                     {%- endif -%}
                     {%- if sub_property.is_pattern_property -%}

--- a/json_schema_for_humans/templates/js/section_properties.html
+++ b/json_schema_for_humans/templates/js/section_properties.html
@@ -16,7 +16,7 @@
                     {%- if sub_property.is_required_property -%}
                         {{ " " }}<span class="badge badge-warning required-property">Required</span>
                     {%- endif -%}
-                    {%- if sub_property.kw_deprecated -%}
+                    {%- if sub_property is deprecated or sub_property.kw_deprecated -%}
                         {{ " " }}<span class="badge badge-danger deprecated-property">Deprecated</span>
                     {%- endif -%}
                     {%- if sub_property.is_pattern_property -%}

--- a/json_schema_for_humans/templates/js_offline/section_properties.html
+++ b/json_schema_for_humans/templates/js_offline/section_properties.html
@@ -16,7 +16,7 @@
                     {%- if sub_property.is_required_property -%}
                         {{ " " }}<span class="badge badge-warning required-property">Required</span>
                     {%- endif -%}
-                    {%- if sub_property is deprecated -%}
+                    {%- if sub_property.kw_deprecated -%}
                         {{ " " }}<span class="badge badge-danger deprecated-property">Deprecated</span>
                     {%- endif -%}
                     {%- if sub_property.is_pattern_property -%}

--- a/json_schema_for_humans/templates/js_offline/section_properties.html
+++ b/json_schema_for_humans/templates/js_offline/section_properties.html
@@ -16,7 +16,7 @@
                     {%- if sub_property.is_required_property -%}
                         {{ " " }}<span class="badge badge-warning required-property">Required</span>
                     {%- endif -%}
-                    {%- if sub_property.kw_deprecated -%}
+                    {%- if sub_property is deprecated or sub_property.kw_deprecated -%}
                         {{ " " }}<span class="badge badge-danger deprecated-property">Deprecated</span>
                     {%- endif -%}
                     {%- if sub_property.is_pattern_property -%}


### PR DESCRIPTION
Hello,

I was trying to mark a property for a project I am working on as deprecated but couldn't get the badge to show up. Using a newer version of JSON Schema the `deprecated` field has been added but wasn't supported here.

I've added a `@property` called `kw_deprecated` so it can be used to check if the property exists or not. I have also updated the Javascript templates to support with the correct tagging now.

