### PR TITLE
Resolve uri references in remote schemas against those schemas' base uris

### DIFF
--- a/json_schema_for_humans/schema/intermediate_representation.py
+++ b/json_schema_for_humans/schema/intermediate_representation.py
@@ -269,6 +269,8 @@ def _resolve_ref(
             referenced_schema_path = uri_part
         elif uri_part.startswith("file:"):
             referenced_schema_path = os.path.realpath(os.path.join(os.path.dirname(current_node.file), uri_part[5:]))
+        elif current_node.file.startswith("http"):
+            referenced_schema_path = urllib.parse.urljoin(current_node.file, uri_part)
         else:
             referenced_schema_path = os.path.realpath(os.path.join(os.path.dirname(current_node.file), uri_part))
     elif current_node.file.startswith("http"):


### PR DESCRIPTION
## Problem

Presently when resolving a remote schema, uri-references within that schema are not correctly resolved against the base uri of the original reference.

For example, my schema references `https://json-schema.org/draft/2020-12/schema` which in turn references `meta/core`.  The current result is a joined path of
```
/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core
```
which doesn't exist, and in turn results in an incomplete doc, and the following output:
```
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core'
WARNING:root:Path __root__ not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/applicator: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/applicator'
WARNING:root:Path __root__ not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/applicator
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/unevaluated: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/unevaluated'
WARNING:root:Path __root__ not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/unevaluated
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/validation: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/validation'
WARNING:root:Path __root__ not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/validation
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/meta-data: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/meta-data'
WARNING:root:Path __root__ not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/meta-data
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/format-annotation: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/format-annotation'
WARNING:root:Path __root__ not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/format-annotation
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/content: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/content'
WARNING:root:Path __root__ not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/content
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/validation: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/validation'
WARNING:root:Path $defs/stringArray not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/validation
WARNING:root:Path $defs/stringArray not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/validation
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core'
WARNING:root:Path $defs/anchorString not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core
WARNING:root:Path $defs/anchorString not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core
WARNING:root:Error loading schema from uri /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core: [Errno 2] No such file or directory: '/home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core'
WARNING:root:Path $defs/uriReferenceString not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core
WARNING:root:Path $defs/uriReferenceString not found in schema at URI /home/me/my-project/https:/json-schema.org/draft/2020-12/meta/core
```


## Fix

Before attempting to join the paths using `os.path.join` as a filesystem path, test if the current file is from a remote URL, and if so, resolve the `uri_part` as a URL path instead.


## Testing

From local testing this has resolved the errors I was getting, and the docs render correctly.  Additionally I ran the `poetry run pytest tests` command from the contributing doc.