### PR TITLE
feat: Add (read more) links to md format

### DIFF
--- a/docs/examples/cases/basic.json
+++ b/docs/examples/cases/basic.json
@@ -25,6 +25,10 @@
         {"type": "null", "title": "no driver licence"},
         {"type": "string", "title": "driver licence id"}
       ]
+    },
+    "middleName": {
+      "type": "string",
+      "title": "Middle Name"
     }
   }
 }

--- a/docs/examples/examples_flat_default/basic.html
+++ b/docs/examples/examples_flat_default/basic.html
@@ -280,6 +280,43 @@
     </div>
 </div>
 
+<div class="card">
+    <div class="card-header" id="middleName">
+        <h2 class="mb-0">
+            <a href="#middleName"><span class="property-name">middleName</span></a></h2>
+    </div>
+
+    <div class="card-body property-definition-div">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#middleName">middleName</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+
+
+
+
+
+
+
+
+
+
+
+        
+
+        
+        
+
+        
+    </div>
+</div>
+
     <footer>
         <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a></p>
     </footer></body>

--- a/docs/examples/examples_js_default/basic.html
+++ b/docs/examples/examples_js_default/basic.html
@@ -242,6 +242,39 @@
         </div>
     </div>
 </div>
+<div class="accordion" id="accordionmiddleName">
+    <div class="card">
+        <div class="card-header" id="headingmiddleName">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#middleName"
+                        aria-expanded="" aria-controls="middleName" onclick="setAnchor('#middleName')"><span class="property-name">middleName</span></button>
+            </h2>
+        </div>
+
+        <div id="middleName"
+             class="collapse property-definition-div" aria-labelledby="headingmiddleName"
+             data-parent="#accordionmiddleName">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#middleName" onclick="anchorLink('middleName')">middleName</a></div><h4>Middle Name</h4><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
 
     <footer>
         <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a></p>

--- a/docs/examples/examples_js_offline_default/basic.html
+++ b/docs/examples/examples_js_offline_default/basic.html
@@ -242,6 +242,39 @@
         </div>
     </div>
 </div>
+<div class="accordion" id="accordionmiddleName">
+    <div class="card">
+        <div class="card-header" id="headingmiddleName">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#middleName"
+                        aria-expanded="" aria-controls="middleName" onclick="setAnchor('#middleName')"><span class="property-name">middleName</span></button>
+            </h2>
+        </div>
+
+        <div id="middleName"
+             class="collapse property-definition-div" aria-labelledby="headingmiddleName"
+             data-parent="#accordionmiddleName">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#middleName" onclick="anchorLink('middleName')">middleName</a></div><h4>Middle Name</h4><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
 
     <footer>
         <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a></p>

--- a/docs/examples/examples_md_default/basic.md
+++ b/docs/examples/examples_md_default/basic.md
@@ -6,6 +6,7 @@
 - [4. Property `Person > driverLicenseId`](#driverLicenseId)
   - [4.1. Property `Person > driverLicenseId > allOf > no driver licence`](#driverLicenseId_allOf_i0)
   - [4.2. Property `Person > driverLicenseId > allOf > driver licence id`](#driverLicenseId_allOf_i1)
+- [5. Property `Person > middleName`](#middleName)
 
 **Title:** Person
 
@@ -15,12 +16,13 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                               | Pattern | Type        | Deprecated | Definition | Title/Description |
-| -------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
-| - [firstName](#firstName )             | No      | string      | No         | -          | Person            |
-| - [lastName](#lastName )               | No      | string      | No         | -          | Person            |
-| - [age](#age )                         | No      | integer     | No         | -          | Person            |
-| - [driverLicenseId](#driverLicenseId ) | No      | Combination | No         | -          | -                 |
+| Property                               | Pattern | Type        | Deprecated | Definition | Title/Description                |
+| -------------------------------------- | ------- | ----------- | ---------- | ---------- | -------------------------------- |
+| - [firstName](#firstName )             | No      | string      | No         | -          | Person [(read more)](#firstName) |
+| - [lastName](#lastName )               | No      | string      | No         | -          | Person [(read more)](#lastName)  |
+| - [age](#age )                         | No      | integer     | No         | -          | Person [(read more)](#age)       |
+| - [driverLicenseId](#driverLicenseId ) | No      | Combination | No         | -          | -                                |
+| - [middleName](#middleName )           | No      | string      | No         | -          | Middle Name                      |
 
 ## <a name="firstName"></a>1. Property `Person > firstName`
 
@@ -84,6 +86,15 @@
 ### <a name="driverLicenseId_allOf_i1"></a>4.2. Property `Person > driverLicenseId > allOf > driver licence id`
 
 **Title:** driver licence id
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+## <a name="middleName"></a>5. Property `Person > middleName`
+
+**Title:** Middle Name
 
 |              |          |
 | ------------ | -------- |

--- a/docs/examples/examples_md_default/broken_ref.md
+++ b/docs/examples/examples_md_default/broken_ref.md
@@ -13,7 +13,7 @@
 
 | Property                   | Pattern | Type   | Deprecated | Definition                                                   | Title/Description                                                                                             |
 | -------------------------- | ------- | ------ | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| - [firstName](#firstName ) | No      | string | No         | -                                                            | Person                                                                                                        |
+| - [firstName](#firstName ) | No      | string | No         | -                                                            | Person [(read more)](#firstName)                                                                              |
 | - [lastName](#lastName )   | No      | object | No         | In a_file_that_does_not_exist_and_will_never_i_hope.lol.json | 😅 ERROR in schema generation, a referenced schema could not be loaded, no documentation here unfortunately 🏜️ |
 
 ## <a name="firstName"></a>1. Property `Person > firstName`

--- a/docs/examples/examples_md_default/html_in_description.md
+++ b/docs/examples/examples_md_default/html_in_description.md
@@ -12,11 +12,11 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                 | Pattern | Type   | Deprecated | Definition | Title/Description     |
-| ---------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
-| - [raw_html](#raw_html )                 | No      | string | No         | -          | Some raw HTML         |
-| - [html_in_markdown](#html_in_markdown ) | No      | string | No         | -          | Some HTML in Markdown |
-| - [json_in_markdown](#json_in_markdown ) | No      | string | No         | -          | Some JSON in Markdown |
+| Property                                 | Pattern | Type   | Deprecated | Definition | Title/Description                                      |
+| ---------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------------------------------ |
+| - [raw_html](#raw_html )                 | No      | string | No         | -          | Some raw HTML [(read more)](#raw_html)                 |
+| - [html_in_markdown](#html_in_markdown ) | No      | string | No         | -          | Some HTML in Markdown [(read more)](#html_in_markdown) |
+| - [json_in_markdown](#json_in_markdown ) | No      | string | No         | -          | Some JSON in Markdown [(read more)](#json_in_markdown) |
 
 ## <a name="raw_html"></a>1. Property `HTML in descriptions > raw_html`
 

--- a/docs/examples/examples_md_default/pattern_properties.md
+++ b/docs/examples/examples_md_default/pattern_properties.md
@@ -14,11 +14,11 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                     | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ---------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [firstName](#firstName )   | No      | string | No         | -          | Person            |
-| - [lastName](#lastName )     | No      | string | No         | -          | Person            |
-| - [$[a-c][0-9]^](#pattern1 ) | Yes     | object | No         | -          | paperSize         |
+| Property                     | Pattern | Type   | Deprecated | Definition | Title/Description                  |
+| ---------------------------- | ------- | ------ | ---------- | ---------- | ---------------------------------- |
+| - [firstName](#firstName )   | No      | string | No         | -          | Person [(read more)](#firstName)   |
+| - [lastName](#lastName )     | No      | string | No         | -          | Person [(read more)](#lastName)    |
+| - [$[a-c][0-9]^](#pattern1 ) | Yes     | object | No         | -          | paperSize [(read more)](#pattern1) |
 
 ## <a name="firstName"></a>1. Property `Person > firstName`
 
@@ -57,10 +57,10 @@ must respect the following conditions
 
 **Description:** Review of a paper size.
 
-| Property                      | Pattern | Type    | Deprecated | Definition | Title/Description |
-| ----------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
-| + [rating](#pattern1_rating ) | No      | integer | No         | -          | Rating            |
-| + [review](#pattern1_review ) | No      | string  | No         | -          | Review            |
+| Property                      | Pattern | Type    | Deprecated | Definition | Title/Description                      |
+| ----------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------- |
+| + [rating](#pattern1_rating ) | No      | integer | No         | -          | Rating [(read more)](#pattern1_rating) |
+| + [review](#pattern1_review ) | No      | string  | No         | -          | Review [(read more)](#pattern1_review) |
 
 ### <a name="pattern1_rating"></a>3.1. Property `Person > paperSize > rating`
 

--- a/docs/examples/examples_md_default/pattern_properties_html_id.md
+++ b/docs/examples/examples_md_default/pattern_properties_html_id.md
@@ -14,12 +14,12 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                           | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ---------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [not_a_pattern](#not_a_pattern ) | No      | object | No         | -          | -                 |
-| - [.*](#pattern1 )                 | Yes     | object | No         | -          | Title 1           |
-| - [..](#pattern2 )                 | Yes     | object | No         | -          | Title 2           |
-| - [^.](#pattern3 )                 | Yes     | object | No         | -          | Title 3           |
+| Property                           | Pattern | Type   | Deprecated | Definition | Title/Description                |
+| ---------------------------------- | ------- | ------ | ---------- | ---------- | -------------------------------- |
+| - [not_a_pattern](#not_a_pattern ) | No      | object | No         | -          | -                                |
+| - [.*](#pattern1 )                 | Yes     | object | No         | -          | Title 1 [(read more)](#pattern1) |
+| - [..](#pattern2 )                 | Yes     | object | No         | -          | Title 2 [(read more)](#pattern2) |
+| - [^.](#pattern3 )                 | Yes     | object | No         | -          | Title 3 [(read more)](#pattern3) |
 
 ## <a name="not_a_pattern"></a>1. Property `Person > not_a_pattern`
 
@@ -29,9 +29,9 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                         | Pattern | Type   | Deprecated | Definition | Title/Description |
-| -------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [.$](#not_a_pattern_pattern1 ) | Yes     | object | No         | -          | Title 4           |
+| Property                         | Pattern | Type   | Deprecated | Definition | Title/Description                              |
+| -------------------------------- | ------- | ------ | ---------- | ---------- | ---------------------------------------------- |
+| - [.$](#not_a_pattern_pattern1 ) | Yes     | object | No         | -          | Title 4 [(read more)](#not_a_pattern_pattern1) |
 
 ### <a name="not_a_pattern_pattern1"></a>1.1. Pattern Property `Person > not_a_pattern > Title 4`
 > All properties whose name matches the regular expression

--- a/docs/examples/examples_md_default/recursive_full_schema.md
+++ b/docs/examples/examples_md_default/recursive_full_schema.md
@@ -96,10 +96,10 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                               | Pattern | Type   | Deprecated | Definition            | Title/Description |
-| ------------------------------------------------------ | ------- | ------ | ---------- | --------------------- | ----------------- |
-| - [SomeName](#DecoratedRecursiveArray_items_SomeName ) | No      | string | No         | -                     | -                 |
-| - [TheThing](#DecoratedRecursiveArray_items_TheThing ) | No      | object | No         | Same as [Bug](#root ) | Bug               |
+| Property                                               | Pattern | Type   | Deprecated | Definition            | Title/Description                                          |
+| ------------------------------------------------------ | ------- | ------ | ---------- | --------------------- | ---------------------------------------------------------- |
+| - [SomeName](#DecoratedRecursiveArray_items_SomeName ) | No      | string | No         | -                     | -                                                          |
+| - [TheThing](#DecoratedRecursiveArray_items_TheThing ) | No      | object | No         | Same as [Bug](#root ) | Bug [(read more)](#DecoratedRecursiveArray_items_TheThing) |
 
 #### <a name="DecoratedRecursiveArray_items_SomeName"></a>3.1.1. Property `Bug > DecoratedRecursiveArray > DecoratedRecursiveArray items > SomeName`
 

--- a/docs/examples/examples_md_default/ref_merge.md
+++ b/docs/examples/examples_md_default/ref_merge.md
@@ -13,10 +13,10 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-| Property                                             | Pattern | Type             | Deprecated | Definition                     | Title/Description     |
-| ---------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------------ | --------------------- |
-| - [aProperty](#aProperty )                           | No      | enum (of string) | No         | In #/definitions/aProperty     | Title from definition |
-| - [aDictPropertyARequired](#aDictPropertyARequired ) | No      | object           | No         | In #/definitions/aDictProperty | -                     |
+| Property                                             | Pattern | Type             | Deprecated | Definition                     | Title/Description                               |
+| ---------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------------ | ----------------------------------------------- |
+| - [aProperty](#aProperty )                           | No      | enum (of string) | No         | In #/definitions/aProperty     | Title from definition [(read more)](#aProperty) |
+| - [aDictPropertyARequired](#aDictPropertyARequired ) | No      | object           | No         | In #/definitions/aDictProperty | -                                               |
 
 ## <a name="aProperty"></a>1. Property `Test > aProperty`
 

--- a/docs/examples/examples_md_default/ref_with_tabs.md
+++ b/docs/examples/examples_md_default/ref_with_tabs.md
@@ -175,9 +175,9 @@
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                          | Pattern | Type  | Deprecated | Definition | Title/Description |
-| ------------------------------------------------- | ------- | ----- | ---------- | ---------- | ----------------- |
-| - [signers](#objectA_signature_oneOf_i0_signers ) | No      | array | No         | -          | Signature         |
+| Property                                          | Pattern | Type  | Deprecated | Definition | Title/Description                                            |
+| ------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------------------------------ |
+| - [signers](#objectA_signature_oneOf_i0_signers ) | No      | array | No         | -          | Signature [(read more)](#objectA_signature_oneOf_i0_signers) |
 
 ##### <a name="objectA_signature_oneOf_i0_signers"></a>1.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers`
 
@@ -213,14 +213,14 @@
 | **Additional properties** | Not allowed          |
 | **Defined in**            | #/definitions/signer |
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------- |
-| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                 |
-| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID            |
-| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key        |
-| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path  |
-| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes          |
-| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature         |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description                                                                         |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                                                                                         |
+| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID [(read more)](#objectA_signature_oneOf_i0_signers_items_keyId)                     |
+| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey)             |
+| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path [(read more)](#objectA_signature_oneOf_i0_signers_items_certificatePath) |
+| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes [(read more)](#objectA_signature_oneOf_i0_signers_items_excludes)                |
+| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature [(read more)](#objectA_signature_oneOf_i0_signers_items_value)                  |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_algorithm"></a>1.1.1.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > algorithm`
 
@@ -298,10 +298,10 @@ Must be one of:
 
 **Description:** Optional. Public key object.
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type          |
-| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                 |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_kty) |
+| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                                                                               |
 
 | All of(Requirement)                                                    |
 | ---------------------------------------------------------------------- |
@@ -325,12 +325,12 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
-| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x)   |
+| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty"></a>1.1.1.1.1.3.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 0 > then > kty`
 
@@ -398,11 +398,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty"></a>1.1.1.1.1.3.2.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 1 > then > kty`
 
@@ -458,11 +458,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus           |
-| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent          |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                             |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty) |
+| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n)    |
+| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty"></a>1.1.1.1.1.3.3.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 2 > then > kty`
 
@@ -594,9 +594,9 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                      | Pattern | Type  | Deprecated | Definition | Title/Description |
-| --------------------------------------------- | ------- | ----- | ---------- | ---------- | ----------------- |
-| - [chain](#objectA_signature_oneOf_i1_chain ) | No      | array | No         | -          | Signature         |
+| Property                                      | Pattern | Type  | Deprecated | Definition | Title/Description                                          |
+| --------------------------------------------- | ------- | ----- | ---------- | ---------- | ---------------------------------------------------------- |
+| - [chain](#objectA_signature_oneOf_i1_chain ) | No      | array | No         | -          | Signature [(read more)](#objectA_signature_oneOf_i1_chain) |
 
 ##### <a name="objectA_signature_oneOf_i1_chain"></a>1.1.2.1. Property `root > objectA > signature > oneOf > item 1 > chain`
 
@@ -645,14 +645,14 @@ Must be one of:
 
 **Description:** Unique top level property for simple signatures. (signaturecore)
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------- |
-| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                 |
-| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID            |
-| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key        |
-| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path  |
-| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes          |
-| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature         |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description                                                                         |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                                                                                         |
+| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID [(read more)](#objectA_signature_oneOf_i0_signers_items_keyId)                     |
+| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey)             |
+| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path [(read more)](#objectA_signature_oneOf_i0_signers_items_certificatePath) |
+| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes [(read more)](#objectA_signature_oneOf_i0_signers_items_excludes)                |
+| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature [(read more)](#objectA_signature_oneOf_i0_signers_items_value)                  |
 
 ##### <a name="objectA_signature_oneOf_i0_signers_items_algorithm"></a>1.1.3.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > algorithm`
 
@@ -730,10 +730,10 @@ Must be one of:
 
 **Description:** Optional. Public key object.
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type          |
-| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                 |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_kty) |
+| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                                                                               |
 
 | All of(Requirement)                                                    |
 | ---------------------------------------------------------------------- |
@@ -757,12 +757,12 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
-| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x)   |
+| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty"></a>1.1.3.3.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 0 > then > kty`
 
@@ -830,11 +830,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty"></a>1.1.3.3.2.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 1 > then > kty`
 
@@ -890,11 +890,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus           |
-| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent          |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                             |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty) |
+| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n)    |
+| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty"></a>1.1.3.3.3.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 2 > then > kty`
 
@@ -1055,9 +1055,9 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                          | Pattern | Type  | Deprecated | Definition | Title/Description |
-| ------------------------------------------------- | ------- | ----- | ---------- | ---------- | ----------------- |
-| - [signers](#objectA_signature_oneOf_i0_signers ) | No      | array | No         | -          | Signature         |
+| Property                                          | Pattern | Type  | Deprecated | Definition | Title/Description                                            |
+| ------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------------------------------ |
+| - [signers](#objectA_signature_oneOf_i0_signers ) | No      | array | No         | -          | Signature [(read more)](#objectA_signature_oneOf_i0_signers) |
 
 ##### <a name="objectA_signature_oneOf_i0_signers"></a>2.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers`
 
@@ -1093,14 +1093,14 @@ Must be one of:
 | **Additional properties** | Not allowed          |
 | **Defined in**            | #/definitions/signer |
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------- |
-| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                 |
-| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID            |
-| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key        |
-| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path  |
-| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes          |
-| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature         |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description                                                                         |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                                                                                         |
+| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID [(read more)](#objectA_signature_oneOf_i0_signers_items_keyId)                     |
+| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey)             |
+| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path [(read more)](#objectA_signature_oneOf_i0_signers_items_certificatePath) |
+| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes [(read more)](#objectA_signature_oneOf_i0_signers_items_excludes)                |
+| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature [(read more)](#objectA_signature_oneOf_i0_signers_items_value)                  |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_algorithm"></a>2.1.1.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > algorithm`
 
@@ -1178,10 +1178,10 @@ Must be one of:
 
 **Description:** Optional. Public key object.
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type          |
-| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                 |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_kty) |
+| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                                                                               |
 
 | All of(Requirement)                                                    |
 | ---------------------------------------------------------------------- |
@@ -1205,12 +1205,12 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
-| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x)   |
+| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty"></a>2.1.1.1.1.3.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 0 > then > kty`
 
@@ -1278,11 +1278,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty"></a>2.1.1.1.1.3.2.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 1 > then > kty`
 
@@ -1338,11 +1338,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus           |
-| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent          |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                             |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty) |
+| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n)    |
+| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty"></a>2.1.1.1.1.3.3.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 2 > then > kty`
 
@@ -1474,9 +1474,9 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                      | Pattern | Type  | Deprecated | Definition | Title/Description |
-| --------------------------------------------- | ------- | ----- | ---------- | ---------- | ----------------- |
-| - [chain](#objectA_signature_oneOf_i1_chain ) | No      | array | No         | -          | Signature         |
+| Property                                      | Pattern | Type  | Deprecated | Definition | Title/Description                                          |
+| --------------------------------------------- | ------- | ----- | ---------- | ---------- | ---------------------------------------------------------- |
+| - [chain](#objectA_signature_oneOf_i1_chain ) | No      | array | No         | -          | Signature [(read more)](#objectA_signature_oneOf_i1_chain) |
 
 ##### <a name="objectA_signature_oneOf_i1_chain"></a>2.1.2.1. Property `root > objectA > signature > oneOf > item 1 > chain`
 
@@ -1525,14 +1525,14 @@ Must be one of:
 
 **Description:** Unique top level property for simple signatures. (signaturecore)
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------- |
-| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                 |
-| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID            |
-| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key        |
-| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path  |
-| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes          |
-| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature         |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description                                                                         |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                                                                                         |
+| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID [(read more)](#objectA_signature_oneOf_i0_signers_items_keyId)                     |
+| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey)             |
+| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path [(read more)](#objectA_signature_oneOf_i0_signers_items_certificatePath) |
+| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes [(read more)](#objectA_signature_oneOf_i0_signers_items_excludes)                |
+| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature [(read more)](#objectA_signature_oneOf_i0_signers_items_value)                  |
 
 ##### <a name="objectA_signature_oneOf_i0_signers_items_algorithm"></a>2.1.3.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > algorithm`
 
@@ -1610,10 +1610,10 @@ Must be one of:
 
 **Description:** Optional. Public key object.
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type          |
-| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                 |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_kty) |
+| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                                                                               |
 
 | All of(Requirement)                                                    |
 | ---------------------------------------------------------------------- |
@@ -1637,12 +1637,12 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
-| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x)   |
+| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty"></a>2.1.3.3.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 0 > then > kty`
 
@@ -1710,11 +1710,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty"></a>2.1.3.3.2.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 1 > then > kty`
 
@@ -1770,11 +1770,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus           |
-| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent          |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                             |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty) |
+| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n)    |
+| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty"></a>2.1.3.3.3.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 2 > then > kty`
 

--- a/docs/examples/examples_md_default/references_url.md
+++ b/docs/examples/examples_md_default/references_url.md
@@ -10,9 +10,9 @@
 
 **Description:** Testing $ref with URL
 
-| Property                   | Pattern | Type   | Deprecated | Definition                                                                                                                     | Title/Description |
-| -------------------------- | ------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
-| - [firstName](#firstName ) | No      | string | No         | In https://raw.githubusercontent.com/coveooss/json-schema-for-humans/main/docs/examples/cases/basic.json#/properties/firstName | Person            |
+| Property                   | Pattern | Type   | Deprecated | Definition                                                                                                                     | Title/Description                |
+| -------------------------- | ------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| - [firstName](#firstName ) | No      | string | No         | In https://raw.githubusercontent.com/coveooss/json-schema-for-humans/main/docs/examples/cases/basic.json#/properties/firstName | Person [(read more)](#firstName) |
 
 ## <a name="firstName"></a>1. Property `root > firstName`
 

--- a/docs/examples/examples_md_default/with_examples.md
+++ b/docs/examples/examples_md_default/with_examples.md
@@ -15,9 +15,9 @@
 
 | Property                   | Pattern | Type    | Deprecated | Definition | Title/Description                   |
 | -------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------- |
-| - [firstName](#firstName ) | No      | string  | No         | -          | Person                              |
-| - [lastName](#lastName )   | No      | string  | No         | -          | Person                              |
-| - [age](#age )             | No      | integer | No         | -          | Person                              |
+| - [firstName](#firstName ) | No      | string  | No         | -          | Person [(read more)](#firstName)    |
+| - [lastName](#lastName )   | No      | string  | No         | -          | Person [(read more)](#lastName)     |
+| - [age](#age )             | No      | integer | No         | -          | Person [(read more)](#age)          |
 | - [moreInfo](#moreInfo )   | No      | object  | No         | -          | Any more info you want as an object |
 
 ## <a name="firstName"></a>1. Property `Person > firstName`

--- a/docs/examples/examples_md_nested_default/basic.md
+++ b/docs/examples/examples_md_nested_default/basic.md
@@ -6,6 +6,7 @@
 - [4. [Optional] Property Person > driverLicenseId](#driverLicenseId)
   - [4.1. Property `Person > driverLicenseId > allOf > no driver licence`](#driverLicenseId_allOf_i0)
   - [4.2. Property `Person > driverLicenseId > allOf > driver licence id`](#driverLicenseId_allOf_i1)
+- [5. [Optional] Property Person > middleName](#middleName)
 
 **Title:** Person
 
@@ -122,6 +123,23 @@
 </blockquote>
 
 </blockquote>
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="middleName"></a>5. [Optional] Property Person > middleName</strong>  
+
+</summary>
+<blockquote>
+
+**Title:** Middle Name
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
 </blockquote>
 </details>

--- a/docs/examples/examples_md_nested_with_badges/basic.md
+++ b/docs/examples/examples_md_nested_with_badges/basic.md
@@ -6,6 +6,7 @@
 - [4. [Optional] Property Person > driverLicenseId](#driverLicenseId)
   - [4.1. Property `Person > driverLicenseId > allOf > no driver licence`](#driverLicenseId_allOf_i0)
   - [4.2. Property `Person > driverLicenseId > allOf > driver licence id`](#driverLicenseId_allOf_i1)
+- [5. [Optional] Property Person > middleName](#middleName)
 
 **Title:** Person
 
@@ -115,6 +116,22 @@
 </blockquote>
 
 </blockquote>
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="middleName"></a>5. [Optional] Property Person > middleName</strong>  
+
+</summary>
+<blockquote>
+
+**Title:** Middle Name
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
 
 </blockquote>
 </details>

--- a/docs/examples/examples_md_with_badges/basic.md
+++ b/docs/examples/examples_md_with_badges/basic.md
@@ -6,6 +6,7 @@
 - [4. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Person > driverLicenseId`](#driverLicenseId)
   - [4.1. Property `Person > driverLicenseId > allOf > no driver licence`](#driverLicenseId_allOf_i0)
   - [4.2. Property `Person > driverLicenseId > allOf > driver licence id`](#driverLicenseId_allOf_i1)
+- [5. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Person > middleName`](#middleName)
 
 **Title:** Person
 
@@ -14,12 +15,13 @@
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                               | Pattern | Type        | Deprecated | Definition | Title/Description |
-| -------------------------------------- | ------- | ----------- | ---------- | ---------- | ----------------- |
-| - [firstName](#firstName )             | No      | string      | No         | -          | Person            |
-| - [lastName](#lastName )               | No      | string      | No         | -          | Person            |
-| - [age](#age )                         | No      | integer     | No         | -          | Person            |
-| - [driverLicenseId](#driverLicenseId ) | No      | Combination | No         | -          | -                 |
+| Property                               | Pattern | Type        | Deprecated | Definition | Title/Description                |
+| -------------------------------------- | ------- | ----------- | ---------- | ---------- | -------------------------------- |
+| - [firstName](#firstName )             | No      | string      | No         | -          | Person [(read more)](#firstName) |
+| - [lastName](#lastName )               | No      | string      | No         | -          | Person [(read more)](#lastName)  |
+| - [age](#age )                         | No      | integer     | No         | -          | Person [(read more)](#age)       |
+| - [driverLicenseId](#driverLicenseId ) | No      | Combination | No         | -          | -                                |
+| - [middleName](#middleName )           | No      | string      | No         | -          | Middle Name                      |
 
 ## <a name="firstName"></a>1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Person > firstName`
 
@@ -78,6 +80,14 @@
 ### <a name="driverLicenseId_allOf_i1"></a>4.2. Property `Person > driverLicenseId > allOf > driver licence id`
 
 **Title:** driver licence id
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+## <a name="middleName"></a>5. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Person > middleName`
+
+**Title:** Middle Name
 
 |          |          |
 | -------- | -------- |

--- a/docs/examples/examples_md_with_badges/broken_ref.md
+++ b/docs/examples/examples_md_with_badges/broken_ref.md
@@ -12,7 +12,7 @@
 
 | Property                   | Pattern | Type   | Deprecated | Definition                                                   | Title/Description                                                                                             |
 | -------------------------- | ------- | ------ | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| - [firstName](#firstName ) | No      | string | No         | -                                                            | Person                                                                                                        |
+| - [firstName](#firstName ) | No      | string | No         | -                                                            | Person [(read more)](#firstName)                                                                              |
 | - [lastName](#lastName )   | No      | object | No         | In a_file_that_does_not_exist_and_will_never_i_hope.lol.json | 😅 ERROR in schema generation, a referenced schema could not be loaded, no documentation here unfortunately 🏜️ |
 
 ## <a name="firstName"></a>1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Person > firstName`

--- a/docs/examples/examples_md_with_badges/html_in_description.md
+++ b/docs/examples/examples_md_with_badges/html_in_description.md
@@ -11,11 +11,11 @@
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                                 | Pattern | Type   | Deprecated | Definition | Title/Description     |
-| ---------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
-| - [raw_html](#raw_html )                 | No      | string | No         | -          | Some raw HTML         |
-| - [html_in_markdown](#html_in_markdown ) | No      | string | No         | -          | Some HTML in Markdown |
-| - [json_in_markdown](#json_in_markdown ) | No      | string | No         | -          | Some JSON in Markdown |
+| Property                                 | Pattern | Type   | Deprecated | Definition | Title/Description                                      |
+| ---------------------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------------------------------ |
+| - [raw_html](#raw_html )                 | No      | string | No         | -          | Some raw HTML [(read more)](#raw_html)                 |
+| - [html_in_markdown](#html_in_markdown ) | No      | string | No         | -          | Some HTML in Markdown [(read more)](#html_in_markdown) |
+| - [json_in_markdown](#json_in_markdown ) | No      | string | No         | -          | Some JSON in Markdown [(read more)](#json_in_markdown) |
 
 ## <a name="raw_html"></a>1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `HTML in descriptions > raw_html`
 

--- a/docs/examples/examples_md_with_badges/pattern_properties.md
+++ b/docs/examples/examples_md_with_badges/pattern_properties.md
@@ -13,11 +13,11 @@
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                     | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ---------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [firstName](#firstName )   | No      | string | No         | -          | Person            |
-| - [lastName](#lastName )     | No      | string | No         | -          | Person            |
-| - [$[a-c][0-9]^](#pattern1 ) | Yes     | object | No         | -          | paperSize         |
+| Property                     | Pattern | Type   | Deprecated | Definition | Title/Description                  |
+| ---------------------------- | ------- | ------ | ---------- | ---------- | ---------------------------------- |
+| - [firstName](#firstName )   | No      | string | No         | -          | Person [(read more)](#firstName)   |
+| - [lastName](#lastName )     | No      | string | No         | -          | Person [(read more)](#lastName)    |
+| - [$[a-c][0-9]^](#pattern1 ) | Yes     | object | No         | -          | paperSize [(read more)](#pattern1) |
 
 ## <a name="firstName"></a>1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Person > firstName`
 
@@ -53,10 +53,10 @@ must respect the following conditions
 
 **Description:** Review of a paper size.
 
-| Property                      | Pattern | Type    | Deprecated | Definition | Title/Description |
-| ----------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
-| + [rating](#pattern1_rating ) | No      | integer | No         | -          | Rating            |
-| + [review](#pattern1_review ) | No      | string  | No         | -          | Review            |
+| Property                      | Pattern | Type    | Deprecated | Definition | Title/Description                      |
+| ----------------------------- | ------- | ------- | ---------- | ---------- | -------------------------------------- |
+| + [rating](#pattern1_rating ) | No      | integer | No         | -          | Rating [(read more)](#pattern1_rating) |
+| + [review](#pattern1_review ) | No      | string  | No         | -          | Review [(read more)](#pattern1_review) |
 
 ### <a name="pattern1_rating"></a>3.1. ![Required](https://img.shields.io/badge/Required-blue) Property `Person > paperSize > rating`
 

--- a/docs/examples/examples_md_with_badges/pattern_properties_html_id.md
+++ b/docs/examples/examples_md_with_badges/pattern_properties_html_id.md
@@ -13,12 +13,12 @@
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                           | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ---------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [not_a_pattern](#not_a_pattern ) | No      | object | No         | -          | -                 |
-| - [.*](#pattern1 )                 | Yes     | object | No         | -          | Title 1           |
-| - [..](#pattern2 )                 | Yes     | object | No         | -          | Title 2           |
-| - [^.](#pattern3 )                 | Yes     | object | No         | -          | Title 3           |
+| Property                           | Pattern | Type   | Deprecated | Definition | Title/Description                |
+| ---------------------------------- | ------- | ------ | ---------- | ---------- | -------------------------------- |
+| - [not_a_pattern](#not_a_pattern ) | No      | object | No         | -          | -                                |
+| - [.*](#pattern1 )                 | Yes     | object | No         | -          | Title 1 [(read more)](#pattern1) |
+| - [..](#pattern2 )                 | Yes     | object | No         | -          | Title 2 [(read more)](#pattern2) |
+| - [^.](#pattern3 )                 | Yes     | object | No         | -          | Title 3 [(read more)](#pattern3) |
 
 ## <a name="not_a_pattern"></a>1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Person > not_a_pattern`
 
@@ -27,9 +27,9 @@
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                         | Pattern | Type   | Deprecated | Definition | Title/Description |
-| -------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [.$](#not_a_pattern_pattern1 ) | Yes     | object | No         | -          | Title 4           |
+| Property                         | Pattern | Type   | Deprecated | Definition | Title/Description                              |
+| -------------------------------- | ------- | ------ | ---------- | ---------- | ---------------------------------------------- |
+| - [.$](#not_a_pattern_pattern1 ) | Yes     | object | No         | -          | Title 4 [(read more)](#not_a_pattern_pattern1) |
 
 ### <a name="not_a_pattern_pattern1"></a>1.1. ![Optional](https://img.shields.io/badge/Optional-yellow) Pattern Property `Person > not_a_pattern > Title 4`
 > All properties whose name matches the regular expression

--- a/docs/examples/examples_md_with_badges/recursive_full_schema.md
+++ b/docs/examples/examples_md_with_badges/recursive_full_schema.md
@@ -90,10 +90,10 @@
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                                               | Pattern | Type   | Deprecated | Definition            | Title/Description |
-| ------------------------------------------------------ | ------- | ------ | ---------- | --------------------- | ----------------- |
-| - [SomeName](#DecoratedRecursiveArray_items_SomeName ) | No      | string | No         | -                     | -                 |
-| - [TheThing](#DecoratedRecursiveArray_items_TheThing ) | No      | object | No         | Same as [Bug](#root ) | Bug               |
+| Property                                               | Pattern | Type   | Deprecated | Definition            | Title/Description                                          |
+| ------------------------------------------------------ | ------- | ------ | ---------- | --------------------- | ---------------------------------------------------------- |
+| - [SomeName](#DecoratedRecursiveArray_items_SomeName ) | No      | string | No         | -                     | -                                                          |
+| - [TheThing](#DecoratedRecursiveArray_items_TheThing ) | No      | object | No         | Same as [Bug](#root ) | Bug [(read more)](#DecoratedRecursiveArray_items_TheThing) |
 
 #### <a name="DecoratedRecursiveArray_items_SomeName"></a>3.1.1. Property `Bug > DecoratedRecursiveArray > DecoratedRecursiveArray items > SomeName`
 

--- a/docs/examples/examples_md_with_badges/ref_merge.md
+++ b/docs/examples/examples_md_with_badges/ref_merge.md
@@ -12,10 +12,10 @@
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                                             | Pattern | Type             | Deprecated | Definition                     | Title/Description     |
-| ---------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------------ | --------------------- |
-| - [aProperty](#aProperty )                           | No      | enum (of string) | No         | In #/definitions/aProperty     | Title from definition |
-| - [aDictPropertyARequired](#aDictPropertyARequired ) | No      | object           | No         | In #/definitions/aDictProperty | -                     |
+| Property                                             | Pattern | Type             | Deprecated | Definition                     | Title/Description                               |
+| ---------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------------ | ----------------------------------------------- |
+| - [aProperty](#aProperty )                           | No      | enum (of string) | No         | In #/definitions/aProperty     | Title from definition [(read more)](#aProperty) |
+| - [aDictPropertyARequired](#aDictPropertyARequired ) | No      | object           | No         | In #/definitions/aDictProperty | -                                               |
 
 ## <a name="aProperty"></a>1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Test > aProperty`
 

--- a/docs/examples/examples_md_with_badges/ref_with_tabs.md
+++ b/docs/examples/examples_md_with_badges/ref_with_tabs.md
@@ -171,9 +171,9 @@
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                          | Pattern | Type  | Deprecated | Definition | Title/Description |
-| ------------------------------------------------- | ------- | ----- | ---------- | ---------- | ----------------- |
-| - [signers](#objectA_signature_oneOf_i0_signers ) | No      | array | No         | -          | Signature         |
+| Property                                          | Pattern | Type  | Deprecated | Definition | Title/Description                                            |
+| ------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------------------------------ |
+| - [signers](#objectA_signature_oneOf_i0_signers ) | No      | array | No         | -          | Signature [(read more)](#objectA_signature_oneOf_i0_signers) |
 
 ##### <a name="objectA_signature_oneOf_i0_signers"></a>1.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers`
 
@@ -207,14 +207,14 @@
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 | **Defined in**            | #/definitions/signer                                           |
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------- |
-| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                 |
-| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID            |
-| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key        |
-| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path  |
-| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes          |
-| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature         |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description                                                                         |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                                                                                         |
+| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID [(read more)](#objectA_signature_oneOf_i0_signers_items_keyId)                     |
+| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey)             |
+| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path [(read more)](#objectA_signature_oneOf_i0_signers_items_certificatePath) |
+| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes [(read more)](#objectA_signature_oneOf_i0_signers_items_excludes)                |
+| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature [(read more)](#objectA_signature_oneOf_i0_signers_items_value)                  |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_algorithm"></a>1.1.1.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > algorithm`
 
@@ -287,10 +287,10 @@ Must be one of:
 
 **Description:** Optional. Public key object.
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type          |
-| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                 |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_kty) |
+| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                                                                               |
 
 | All of(Requirement)                                                    |
 | ---------------------------------------------------------------------- |
@@ -312,12 +312,12 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
-| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x)   |
+| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty"></a>1.1.1.1.1.3.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 0 > then > kty`
 
@@ -379,11 +379,11 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty"></a>1.1.1.1.1.3.2.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 1 > then > kty`
 
@@ -434,11 +434,11 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus           |
-| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent          |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                             |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty) |
+| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n)    |
+| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty"></a>1.1.1.1.1.3.3.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 2 > then > kty`
 
@@ -560,9 +560,9 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                      | Pattern | Type  | Deprecated | Definition | Title/Description |
-| --------------------------------------------- | ------- | ----- | ---------- | ---------- | ----------------- |
-| - [chain](#objectA_signature_oneOf_i1_chain ) | No      | array | No         | -          | Signature         |
+| Property                                      | Pattern | Type  | Deprecated | Definition | Title/Description                                          |
+| --------------------------------------------- | ------- | ----- | ---------- | ---------- | ---------------------------------------------------------- |
+| - [chain](#objectA_signature_oneOf_i1_chain ) | No      | array | No         | -          | Signature [(read more)](#objectA_signature_oneOf_i1_chain) |
 
 ##### <a name="objectA_signature_oneOf_i1_chain"></a>1.1.2.1. Property `root > objectA > signature > oneOf > item 1 > chain`
 
@@ -608,14 +608,14 @@ Must be one of:
 
 **Description:** Unique top level property for simple signatures. (signaturecore)
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------- |
-| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                 |
-| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID            |
-| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key        |
-| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path  |
-| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes          |
-| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature         |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description                                                                         |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                                                                                         |
+| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID [(read more)](#objectA_signature_oneOf_i0_signers_items_keyId)                     |
+| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey)             |
+| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path [(read more)](#objectA_signature_oneOf_i0_signers_items_certificatePath) |
+| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes [(read more)](#objectA_signature_oneOf_i0_signers_items_excludes)                |
+| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature [(read more)](#objectA_signature_oneOf_i0_signers_items_value)                  |
 
 ##### <a name="objectA_signature_oneOf_i0_signers_items_algorithm"></a>1.1.3.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > algorithm`
 
@@ -688,10 +688,10 @@ Must be one of:
 
 **Description:** Optional. Public key object.
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type          |
-| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                 |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_kty) |
+| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                                                                               |
 
 | All of(Requirement)                                                    |
 | ---------------------------------------------------------------------- |
@@ -713,12 +713,12 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
-| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x)   |
+| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty"></a>1.1.3.3.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 0 > then > kty`
 
@@ -780,11 +780,11 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty"></a>1.1.3.3.2.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 1 > then > kty`
 
@@ -835,11 +835,11 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus           |
-| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent          |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                             |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty) |
+| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n)    |
+| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty"></a>1.1.3.3.3.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 2 > then > kty`
 
@@ -988,9 +988,9 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                          | Pattern | Type  | Deprecated | Definition | Title/Description |
-| ------------------------------------------------- | ------- | ----- | ---------- | ---------- | ----------------- |
-| - [signers](#objectA_signature_oneOf_i0_signers ) | No      | array | No         | -          | Signature         |
+| Property                                          | Pattern | Type  | Deprecated | Definition | Title/Description                                            |
+| ------------------------------------------------- | ------- | ----- | ---------- | ---------- | ------------------------------------------------------------ |
+| - [signers](#objectA_signature_oneOf_i0_signers ) | No      | array | No         | -          | Signature [(read more)](#objectA_signature_oneOf_i0_signers) |
 
 ##### <a name="objectA_signature_oneOf_i0_signers"></a>2.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers`
 
@@ -1024,14 +1024,14 @@ Must be one of:
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 | **Defined in**            | #/definitions/signer                                           |
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------- |
-| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                 |
-| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID            |
-| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key        |
-| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path  |
-| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes          |
-| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature         |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description                                                                         |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                                                                                         |
+| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID [(read more)](#objectA_signature_oneOf_i0_signers_items_keyId)                     |
+| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey)             |
+| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path [(read more)](#objectA_signature_oneOf_i0_signers_items_certificatePath) |
+| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes [(read more)](#objectA_signature_oneOf_i0_signers_items_excludes)                |
+| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature [(read more)](#objectA_signature_oneOf_i0_signers_items_value)                  |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_algorithm"></a>2.1.1.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > algorithm`
 
@@ -1104,10 +1104,10 @@ Must be one of:
 
 **Description:** Optional. Public key object.
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type          |
-| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                 |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_kty) |
+| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                                                                               |
 
 | All of(Requirement)                                                    |
 | ---------------------------------------------------------------------- |
@@ -1129,12 +1129,12 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
-| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x)   |
+| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty"></a>2.1.1.1.1.3.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 0 > then > kty`
 
@@ -1196,11 +1196,11 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty"></a>2.1.1.1.1.3.2.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 1 > then > kty`
 
@@ -1251,11 +1251,11 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus           |
-| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent          |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                             |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty) |
+| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n)    |
+| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty"></a>2.1.1.1.1.3.3.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 2 > then > kty`
 
@@ -1377,9 +1377,9 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                      | Pattern | Type  | Deprecated | Definition | Title/Description |
-| --------------------------------------------- | ------- | ----- | ---------- | ---------- | ----------------- |
-| - [chain](#objectA_signature_oneOf_i1_chain ) | No      | array | No         | -          | Signature         |
+| Property                                      | Pattern | Type  | Deprecated | Definition | Title/Description                                          |
+| --------------------------------------------- | ------- | ----- | ---------- | ---------- | ---------------------------------------------------------- |
+| - [chain](#objectA_signature_oneOf_i1_chain ) | No      | array | No         | -          | Signature [(read more)](#objectA_signature_oneOf_i1_chain) |
 
 ##### <a name="objectA_signature_oneOf_i1_chain"></a>2.1.2.1. Property `root > objectA > signature > oneOf > item 1 > chain`
 
@@ -1425,14 +1425,14 @@ Must be one of:
 
 **Description:** Unique top level property for simple signatures. (signaturecore)
 
-| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------- |
-| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                 |
-| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID            |
-| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key        |
-| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path  |
-| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes          |
-| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature         |
+| Property                                                                        | Pattern | Type            | Deprecated | Definition                 | Title/Description                                                                         |
+| ------------------------------------------------------------------------------- | ------- | --------------- | ---------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| + [algorithm](#objectA_signature_oneOf_i0_signers_items_algorithm )             | No      | Combination     | No         | -                          | -                                                                                         |
+| - [keyId](#objectA_signature_oneOf_i0_signers_items_keyId )                     | No      | string          | No         | -                          | Key ID [(read more)](#objectA_signature_oneOf_i0_signers_items_keyId)                     |
+| - [publicKey](#objectA_signature_oneOf_i0_signers_items_publicKey )             | No      | object          | No         | In #/definitions/publicKey | Public key [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey)             |
+| - [certificatePath](#objectA_signature_oneOf_i0_signers_items_certificatePath ) | No      | array of string | No         | -                          | Certificate path [(read more)](#objectA_signature_oneOf_i0_signers_items_certificatePath) |
+| - [excludes](#objectA_signature_oneOf_i0_signers_items_excludes )               | No      | array of string | No         | -                          | Excludes [(read more)](#objectA_signature_oneOf_i0_signers_items_excludes)                |
+| + [value](#objectA_signature_oneOf_i0_signers_items_value )                     | No      | string          | No         | -                          | Signature [(read more)](#objectA_signature_oneOf_i0_signers_items_value)                  |
 
 ##### <a name="objectA_signature_oneOf_i0_signers_items_algorithm"></a>2.1.3.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > algorithm`
 
@@ -1505,10 +1505,10 @@ Must be one of:
 
 **Description:** Optional. Public key object.
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type          |
-| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                 |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition               | Title/Description                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ------------------------ | ------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty )               | No      | enum (of string) | No         | In #/definitions/keyType | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_kty) |
+| - [](#objectA_signature_oneOf_i0_signers_items_publicKey_additionalProperties ) | No      | object           | No         | -                        | -                                                                               |
 
 | All of(Requirement)                                                    |
 | ---------------------------------------------------------------------- |
@@ -1530,12 +1530,12 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
-| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_x)   |
+| + [y](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_y)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i0_then_kty"></a>2.1.3.3.1.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 0 > then > kty`
 
@@ -1597,11 +1597,11 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name        |
-| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate        |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                               |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty)   |
+| + [crv](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv ) | No      | enum (of string) | No         | -                                                                       | Curve name [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_crv) |
+| + [x](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x )     | No      | string           | No         | -                                                                       | Coordinate [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_x)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i1_then_kty"></a>2.1.3.3.2.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 1 > then > kty`
 
@@ -1652,11 +1652,11 @@ Must be one of:
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description |
-| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | ----------------- |
-| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type          |
-| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus           |
-| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent          |
+| Property                                                                        | Pattern | Type             | Deprecated | Definition                                                              | Title/Description                                                                             |
+| ------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| + [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty ) | No      | enum (of string) | No         | Same as [kty](#objectA_signature_oneOf_i0_signers_items_publicKey_kty ) | Key type [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty) |
+| + [n](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n )     | No      | string           | No         | -                                                                       | Modulus [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_n)    |
+| + [e](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e )     | No      | string           | No         | -                                                                       | Exponent [(read more)](#objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_e)   |
 
 ###### <a name="objectA_signature_oneOf_i0_signers_items_publicKey_allOf_i2_then_kty"></a>2.1.3.3.3.1.1. Property `root > objectA > signature > oneOf > item 0 > signers > Signature > publicKey > allOf > item 2 > then > kty`
 

--- a/docs/examples/examples_md_with_badges/references_url.md
+++ b/docs/examples/examples_md_with_badges/references_url.md
@@ -9,9 +9,9 @@
 
 **Description:** Testing $ref with URL
 
-| Property                   | Pattern | Type   | Deprecated | Definition                                                                                                                     | Title/Description |
-| -------------------------- | ------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
-| - [firstName](#firstName ) | No      | string | No         | In https://raw.githubusercontent.com/coveooss/json-schema-for-humans/main/docs/examples/cases/basic.json#/properties/firstName | Person            |
+| Property                   | Pattern | Type   | Deprecated | Definition                                                                                                                     | Title/Description                |
+| -------------------------- | ------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| - [firstName](#firstName ) | No      | string | No         | In https://raw.githubusercontent.com/coveooss/json-schema-for-humans/main/docs/examples/cases/basic.json#/properties/firstName | Person [(read more)](#firstName) |
 
 ## <a name="firstName"></a>1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `root > firstName`
 

--- a/docs/examples/examples_md_with_badges/with_examples.md
+++ b/docs/examples/examples_md_with_badges/with_examples.md
@@ -14,9 +14,9 @@
 
 | Property                   | Pattern | Type    | Deprecated | Definition | Title/Description                   |
 | -------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------- |
-| - [firstName](#firstName ) | No      | string  | No         | -          | Person                              |
-| - [lastName](#lastName )   | No      | string  | No         | -          | Person                              |
-| - [age](#age )             | No      | integer | No         | -          | Person                              |
+| - [firstName](#firstName ) | No      | string  | No         | -          | Person [(read more)](#firstName)    |
+| - [lastName](#lastName )   | No      | string  | No         | -          | Person [(read more)](#lastName)     |
+| - [age](#age )             | No      | integer | No         | -          | Person [(read more)](#age)          |
 | - [moreInfo](#moreInfo )   | No      | object  | No         | -          | Any more info you want as an object |
 
 ## <a name="firstName"></a>1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `Person > firstName`

--- a/json_schema_for_humans/md_template.py
+++ b/json_schema_for_humans/md_template.py
@@ -358,9 +358,15 @@ class MarkdownTemplate(object):
                         line.append("-")
                 elif field == "Title/Description":
                     # title or description
-                    description = sub_property.description or "-"
-                    if sub_property.title:
+                    if sub_property.title and sub_property.description:
+                        # Both title and description exist - show title with read more link
+                        description = f"{sub_property.title} [(read more)](#{sub_property.html_id})"
+                    elif sub_property.title:
+                        # Only title exists
                         description = sub_property.title
+                    else:
+                        # Only description exists (or neither)
+                        description = sub_property.description or "-"
                     line.append(escape_for_table(description))
                 else:
                     raise ValueError(f"Unknown field {field} for properties table")


### PR DESCRIPTION
Hey all,

Here's a little quality of life improvement that I would like to use for the schema documentation in [Nix](https://github.com/NixOS/nix). ([wip](https://github.com/NixOS/nix/pull/14269#discussion_r2441045988))
Thank you for considering!

Cheers, Robert

-----

Add read more links to the properties table in the `md` format when it has both title and description.


When a schema property has both a title and description, the table now displays the title with a "(read more)" link to the detailed section. This keeps tables compact and scannable while highlighting the existence of the full documentation.

That would otherwise be easy to miss, especially when embedded in documentation where links in definition lists are merely anchors and readers are used to ignoring those.

Changes:
- Add (read more) in md_template.py
- Add "middleName" to basic.json example to showcase and test a property with a title and no description. The other combinators were already covered.

To be specific the behavior for all four combinations:
```
- title and description: (changed)     Shows "Title [(read more)](#anchor)"
- title:                 (unchanged)   Shows "Title"   (no link needed)
- description:           (unchanged)   Shows description text
- none:                  (unchanged)   Shows "-" placeholder
```

Things checked:
- The other formats do not have tables that serve as a table of contents, so this change does not apply to them.
- Viewed all four combinations, which render correctly from generated output Examples include: basic.json (all 4 cases), array_advanced.json