### PR TITLE
(fix) Display long default values

### DIFF
--- a/docs/examples/examples_flat_default/schema_doc.css
+++ b/docs/examples/examples_flat_default/schema_doc.css
@@ -70,18 +70,18 @@ body {
 }
 
 .badge.value-type,.badge.no-additional,.badge.default-value {
-  font-size: 120%;
-  margin-right: 5px;
-  margin-bottom: 10px;
+    font-size: 120%;
+    margin-right: 5px;
+    margin-bottom: 10px;
 }
 
 .badge.default-value {
-  max-width: 100%;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  white-space: normal;
-  display: inline-block;
-  vertical-align: top;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    white-space: normal;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .badge.restriction {

--- a/docs/examples/examples_flat_default/schema_doc.css
+++ b/docs/examples/examples_flat_default/schema_doc.css
@@ -70,9 +70,18 @@ body {
 }
 
 .badge.value-type,.badge.no-additional,.badge.default-value {
-    font-size: 120%;
-    margin-right: 5px;
-    margin-bottom: 10px;
+  font-size: 120%;
+  margin-right: 5px;
+  margin-bottom: 10px;
+}
+
+.badge.default-value {
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  display: inline-block;
+  vertical-align: top;
 }
 
 .badge.restriction {

--- a/docs/examples/examples_js_default/schema_doc.css
+++ b/docs/examples/examples_js_default/schema_doc.css
@@ -73,15 +73,15 @@ body {
 }
 
 .badge.default-value {
-  font-size: 120%;
-  margin-left: 5px;
-  margin-bottom: 10px;
-  max-width: 100%;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  white-space: normal;
-  display: inline-block;
-  vertical-align: top;
+    font-size: 120%;
+    margin-left: 5px;
+    margin-bottom: 10px;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    white-space: normal;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .badge.restriction {

--- a/docs/examples/examples_js_default/schema_doc.css
+++ b/docs/examples/examples_js_default/schema_doc.css
@@ -72,11 +72,16 @@ body {
     margin-bottom: 10px;
 }
 
-
 .badge.default-value {
-    font-size: 120%;
-    margin-left: 5px;
-    margin-bottom: 10px;
+  font-size: 120%;
+  margin-left: 5px;
+  margin-bottom: 10px;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  display: inline-block;
+  vertical-align: top;
 }
 
 .badge.restriction {

--- a/docs/examples/examples_js_offline_default/css/schema_doc.css
+++ b/docs/examples/examples_js_offline_default/css/schema_doc.css
@@ -73,15 +73,15 @@ body {
 }
 
 .badge.default-value {
-  font-size: 120%;
-  margin-left: 5px;
-  margin-bottom: 10px;
-  max-width: 100%;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  white-space: normal;
-  display: inline-block;
-  vertical-align: top;
+    font-size: 120%;
+    margin-left: 5px;
+    margin-bottom: 10px;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    white-space: normal;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .badge.restriction {

--- a/docs/examples/examples_js_offline_default/css/schema_doc.css
+++ b/docs/examples/examples_js_offline_default/css/schema_doc.css
@@ -72,11 +72,16 @@ body {
     margin-bottom: 10px;
 }
 
-
 .badge.default-value {
-    font-size: 120%;
-    margin-left: 5px;
-    margin-bottom: 10px;
+  font-size: 120%;
+  margin-left: 5px;
+  margin-bottom: 10px;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  display: inline-block;
+  vertical-align: top;
 }
 
 .badge.restriction {

--- a/json_schema_for_humans/templates/flat/schema_doc.css
+++ b/json_schema_for_humans/templates/flat/schema_doc.css
@@ -70,18 +70,18 @@ body {
 }
 
 .badge.value-type,.badge.no-additional,.badge.default-value {
-  font-size: 120%;
-  margin-right: 5px;
-  margin-bottom: 10px;
+    font-size: 120%;
+    margin-right: 5px;
+    margin-bottom: 10px;
 }
 
 .badge.default-value {
-  max-width: 100%;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  white-space: normal;
-  display: inline-block;
-  vertical-align: top;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    white-space: normal;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .badge.restriction {

--- a/json_schema_for_humans/templates/flat/schema_doc.css
+++ b/json_schema_for_humans/templates/flat/schema_doc.css
@@ -70,9 +70,18 @@ body {
 }
 
 .badge.value-type,.badge.no-additional,.badge.default-value {
-    font-size: 120%;
-    margin-right: 5px;
-    margin-bottom: 10px;
+  font-size: 120%;
+  margin-right: 5px;
+  margin-bottom: 10px;
+}
+
+.badge.default-value {
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  display: inline-block;
+  vertical-align: top;
 }
 
 .badge.restriction {

--- a/json_schema_for_humans/templates/js/schema_doc.css
+++ b/json_schema_for_humans/templates/js/schema_doc.css
@@ -73,15 +73,15 @@ body {
 }
 
 .badge.default-value {
-  font-size: 120%;
-  margin-left: 5px;
-  margin-bottom: 10px;
-  max-width: 100%;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  white-space: normal;
-  display: inline-block;
-  vertical-align: top;
+    font-size: 120%;
+    margin-left: 5px;
+    margin-bottom: 10px;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    white-space: normal;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .badge.restriction {

--- a/json_schema_for_humans/templates/js/schema_doc.css
+++ b/json_schema_for_humans/templates/js/schema_doc.css
@@ -72,11 +72,16 @@ body {
     margin-bottom: 10px;
 }
 
-
 .badge.default-value {
-    font-size: 120%;
-    margin-left: 5px;
-    margin-bottom: 10px;
+  font-size: 120%;
+  margin-left: 5px;
+  margin-bottom: 10px;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  display: inline-block;
+  vertical-align: top;
 }
 
 .badge.restriction {

--- a/json_schema_for_humans/templates/js_offline/css/schema_doc.css
+++ b/json_schema_for_humans/templates/js_offline/css/schema_doc.css
@@ -73,15 +73,15 @@ body {
 }
 
 .badge.default-value {
-  font-size: 120%;
-  margin-left: 5px;
-  margin-bottom: 10px;
-  max-width: 100%;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  white-space: normal;
-  display: inline-block;
-  vertical-align: top;
+    font-size: 120%;
+    margin-left: 5px;
+    margin-bottom: 10px;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    white-space: normal;
+    display: inline-block;
+    vertical-align: top;
 }
 
 .badge.restriction {

--- a/json_schema_for_humans/templates/js_offline/css/schema_doc.css
+++ b/json_schema_for_humans/templates/js_offline/css/schema_doc.css
@@ -72,11 +72,16 @@ body {
     margin-bottom: 10px;
 }
 
-
 .badge.default-value {
-    font-size: 120%;
-    margin-left: 5px;
-    margin-bottom: 10px;
+  font-size: 120%;
+  margin-left: 5px;
+  margin-bottom: 10px;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  display: inline-block;
+  vertical-align: top;
 }
 
 .badge.restriction {


### PR DESCRIPTION
When a default value is long, it overflows the page

Before the fix

<img width="636" height="399" alt="image" src="https://github.com/user-attachments/assets/0b0fc003-5cf0-46fc-969e-a2f4a2f400ab" />


After the fix

<img width="563" height="543" alt="Screenshot 2026-02-27 at 21 06 11" src="https://github.com/user-attachments/assets/08861e98-e98b-4b6c-80cf-2d5a7d931d28" />
