### PR TITLE
feat: add Python 3.14 support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Harden Runner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Development Status :: 6 - Mature",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.9,3.10,3.11,3.12,3.13}
+envlist = py{3.9,3.10,3.11,3.12,3.13,3.14}
 isolated_build = True
 allowlist_externals =
     poetry


### PR DESCRIPTION
## Summary

Adds Python 3.14 to the supported versions matrix.

### Changes
- `tox.ini`: added `3.14` to `envlist`
- `.github/workflows/pythonpackage.yml`: added `"3.14"` to CI matrix
- `pyproject.toml`: added `Programming Language :: Python :: 3.14` trove classifier

### Verification
All 335 tests pass locally under Python 3.14.3 (`tox -e py3.14`).

> Note: there are two `SyntaxWarning: 'return' in a 'finally' block` warnings from `pluggy` — that's an upstream issue in pluggy, not in this project.